### PR TITLE
Remove file_exists, is not needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mollie/mollie-api-php",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "description": "Mollie API client library for PHP",
     "homepage": "https://github.com/mollie/mollie-api-php",
     "license": "BSD-2-Clause",

--- a/src/Mollie/API/Autoloader.php
+++ b/src/Mollie/API/Autoloader.php
@@ -41,7 +41,7 @@ class Mollie_API_Autoloader
 			$file_name = str_replace("_", "/", $class_name);
 			$file_name = realpath(dirname(__FILE__) . "/../../{$file_name}.php");
 
-			if (file_exists($file_name))
+			if ($file_name !== false)
 			{
 				require $file_name;
 			}

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -34,7 +34,7 @@ class Mollie_API_Client
 	/**
 	 * Version of our client.
 	 */
-	const CLIENT_VERSION = "1.2.7";
+	const CLIENT_VERSION = "1.2.8";
 
 	/**
 	 * Endpoint of the remote API.


### PR DESCRIPTION
Very minor but: realpath does the checking already and returns false when the file does not exists or an other error occurs.