### PR TITLE
disable Expect header

### DIFF
--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -329,6 +329,7 @@ class Mollie_API_Client
 			"Authorization: Bearer {$this->api_key}",
 			"User-Agent: {$user_agent}",
 			"X-Mollie-Client-Info: " . php_uname(),
+			"Expect:",
 		);
 
 		curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, $http_method);


### PR DESCRIPTION
The empty 'Expect' header, is saying to the server: please accept the body right now. This can speed up the request

More info: https://gist.github.com/perusio/1724301