### PR TITLE
Fix cancel() parameter in 17-cancel-subscription.php

### DIFF
--- a/examples/17-cancel-subscription.php
+++ b/examples/17-cancel-subscription.php
@@ -29,7 +29,7 @@ try
 	 *
 	 * See: https://www.mollie.com/nl/docs/reference/subscriptions/cancel
 	 */
-	$cancelledSubscription = $mollie->customers_subscriptions->with($customer)->cancel($subscription);
+	$cancelledSubscription = $mollie->customers_subscriptions->with($customer)->cancel($subscription->id);
 
 	/*
 	 * The subscription status should now be cancelled

--- a/examples/17-cancel-subscription.php
+++ b/examples/17-cancel-subscription.php
@@ -20,7 +20,7 @@ try
 	 * Generate a unique subscription id for this example. It is important to include this unique attribute
 	 * in the webhookUrl (below) so new payments can be associated with this subscription.
 	 */
-	$subscriptionId = isset($_GET['subscription_id']) ? $_GET['subscription_id'] : '';
+	$subscriptionId = $_GET['subscription_id'];
 
 	// retrieve subscription
 	$subscription = $mollie->customers_subscriptions->with($customer)->get($subscriptionId);


### PR DESCRIPTION
`cancel()` method in `Mollie_API_Resource_Customers_Subscriptions` only accepts the subscription_id string.