### PR TITLE
Add isRecurring method

### DIFF
--- a/src/Mollie/API/Object/Payment.php
+++ b/src/Mollie/API/Object/Payment.php
@@ -322,6 +322,16 @@ class Mollie_API_Object_Payment
 	}
 
 	/**
+	 * Is this payment recurring?
+	 *
+	 * @return bool
+	 */
+	public function isRecurring ()
+	{
+		return $this->recurringType !== self::RECURRINGTYPE_NONE;
+	}
+
+	/**
 	 * Is this payment charged back?
 	 *
 	 * @return bool


### PR DESCRIPTION
So it's possible to do `$payment->isRecurring()` instead of `$payment->recurringType === \Mollie_API_Object_Payment::RECURRINGTYPE_FIRST`