### PR TITLE
Fixes #45. Do not attempt to decode the response for 204

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mollie/mollie-api-php",
     "description": "Mollie API client library for PHP",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "homepage": "https://github.com/mollie/mollie-api-php",
     "license": "BSD-2-Clause",
     "authors": [

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -34,7 +34,7 @@ class Mollie_API_Client
 	/**
 	 * Version of our client.
 	 */
-	const CLIENT_VERSION = "1.8.0";
+	const CLIENT_VERSION = "1.8.1";
 
 	/**
 	 * Endpoint of the remote API.
@@ -49,6 +49,8 @@ class Mollie_API_Client
 	const HTTP_GET    = "GET";
 	const HTTP_POST   = "POST";
 	const HTTP_DELETE = "DELETE";
+
+	const HTTP_STATUS_NO_CONTENT = 204;
 
 	/**
 	 * @var string
@@ -175,6 +177,11 @@ class Mollie_API_Client
 	 * @var string
 	 */
 	protected $pem_path;
+
+	/**
+	 * @var int
+	 */
+	protected $last_http_response_status_code;
 
 	/**
 	 * @throws Mollie_API_Exception_IncompatiblePlatform
@@ -392,6 +399,8 @@ class Mollie_API_Client
 			$body = curl_exec($this->ch);
 		}
 
+		$this->last_http_response_status_code = (int) curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
+
 		if (curl_errno($this->ch))
 		{
 			$message = "Unable to communicate with Mollie (".curl_errno($this->ch)."): " . curl_error($this->ch) . ".";
@@ -439,5 +448,15 @@ class Mollie_API_Client
 		}
 
 		return $checker;
+	}
+
+	/**
+	 * @deprecated Do not use this method, it should only be used internally
+	 *
+	 * @return int
+	 */
+	public function getLastHttpResponseStatusCode ()
+	{
+		return $this->last_http_response_status_code;
 	}
 }

--- a/src/Mollie/API/Resource/Base.php
+++ b/src/Mollie/API/Resource/Base.php
@@ -152,6 +152,11 @@ abstract class Mollie_API_Resource_Base
 			"{$rest_resource}/{$id}"
 		);
 
+		if ($result === NULL)
+		{
+			return NULL;
+		}
+
 		return $this->copy($result, $this->getResourceObject());
 	}
 
@@ -325,6 +330,11 @@ abstract class Mollie_API_Resource_Base
 	protected function performApiCall($http_method, $api_method, $http_body = NULL)
 	{
 		$body = $this->api->performHttpCall($http_method, $api_method, $http_body);
+
+		if ($this->api->getLastHttpResponseStatusCode() == Mollie_API_Client::HTTP_STATUS_NO_CONTENT)
+		{
+			return NULL;
+		}
 
 		if (empty($body))
 		{

--- a/tests/apiUnitTest.php
+++ b/tests/apiUnitTest.php
@@ -23,7 +23,7 @@ class Mollie_ApiUnitTest extends PHPUnit_Framework_TestCase
 			->getMock();
 
 		$this->api = $this->getMockBuilder("Mollie_API_Client")
-			->setMethods(array("performHttpCall", "getCompatibilityChecker"))
+			->setMethods(array("performHttpCall", "getCompatibilityChecker", "getLastHttpResponseStatusCode"))
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -366,6 +366,20 @@ class Mollie_ApiUnitTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals("sub_d0b0E3EA3v", $deleted_subscription->id);
 
 		$this->assertTrue($deleted_subscription->isCancelled());
+	}
+
+	public function testDeleteCustomerWorksCorrectly ()
+	{
+		$this->api->expects($this->once())
+			->method('getLastHttpResponseStatusCode')
+			->willReturn(Mollie_API_Client::HTTP_STATUS_NO_CONTENT);
+
+		$this->api->expects($this->once())
+			->method("performHttpCall")
+			->with(Mollie_API_Client::HTTP_DELETE, "customers/cst_3EA3vd0b0E")
+			->willReturn(NULL);
+
+		$this->api->customers->delete("cst_3EA3vd0b0E");
 	}
 
 	public function testUndefinedResourceCallsResourceEndpoint ()


### PR DESCRIPTION
Do not attempt to decode the response and/or create an object when HTTP status code 204 No Content is returned