### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: php
+dist: trusty
 
 php:
-- 5.3
 - 5.4
 - 5.5
 - 5.6
 - 7.0
 - 7.1
+- hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+      sudo: true
 
 sudo: false
 


### PR DESCRIPTION
Few reasons:

- Re-add `hhvm`, it isn't supported anymore on `dist: precise` but is on `dist: trusty`
- `5.3` isn't supported anymore on `dist: trusty`
- `dist: trusty` will become the default somewhere between now and the end of august
- `dist: precise` will require `sudo` somewhere in september

See also: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming