### PR TITLE
Implement a ConnectionError exception

### DIFF
--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -392,14 +392,10 @@ class Mollie_API_Client
 
 		if (curl_errno($this->ch))
 		{
-			$message = "Unable to communicate with Mollie (".curl_errno($this->ch)."): " . curl_error($this->ch) . ".";
-
 			$this->closeTcpConnection();
 			
-			$exception = new Mollie_API_Exception_ConnectionError($message);
-			$exception->errorCode = curl_errno($this->ch);
-			$exception->errorMessage = curl_error($this->ch);
-			
+			$exception = Mollie_API_Exception_ConnectionError::fromCurlFailure($this->ch);
+
 			throw $exception;
 		}
 

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -395,7 +395,12 @@ class Mollie_API_Client
 			$message = "Unable to communicate with Mollie (".curl_errno($this->ch)."): " . curl_error($this->ch) . ".";
 
 			$this->closeTcpConnection();
-			throw new Mollie_API_Exception($message);
+			
+			$exception = new Mollie_API_Exception_ConnectionError($message);
+			$exception->errorCode = curl_errno($this->ch);
+			$exception->errorMessage = curl_error($this->ch);
+			
+			throw $exception;
 		}
 
 		if (!function_exists("curl_reset"))

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -393,10 +393,8 @@ class Mollie_API_Client
 		if (curl_errno($this->ch))
 		{
 			$this->closeTcpConnection();
-			
-			$exception = Mollie_API_Exception_ConnectionError::fromCurlFailure($this->ch);
 
-			throw $exception;
+			throw Mollie_API_Exception_ConnectionError::fromCurlFailure($this->ch);
 		}
 
 		if (!function_exists("curl_reset"))

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -392,9 +392,15 @@ class Mollie_API_Client
 
 		if (curl_errno($this->ch))
 		{
+			$exception = Mollie_API_Exception_ConnectionError::fromCurlFailure($this->ch);
+
 			$this->closeTcpConnection();
 
-			throw Mollie_API_Exception_ConnectionError::fromCurlFailure($this->ch);
+			/*
+			 * We intentionally throw the exception after creating it and closing the connection because closing the
+			 * connection will reset the cull resource to null.
+			 */
+			throw $exception;
 		}
 
 		if (!function_exists("curl_reset"))

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) 2013, Mollie B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * @license     Berkeley Software Distribution License (BSD-License 2) http://www.opensource.org/licenses/bsd-license.php
+ * @author      Mollie B.V. <info@mollie.com>
+ * @copyright   Mollie B.V.
+ * @link        https://www.mollie.com
+ */
+class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
+{
+}

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (c) 2013, Mollie B.V.
  * All rights reserved.
@@ -31,59 +32,43 @@
  */
 class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
 {
-    /**
-     * @var int
-     */
+	/**
+	 * @var int
+	 */
 	private $curlErrorCode;
 
-    /**
-     * @var string
-     */
+	/**
+	 * @var string
+	 */
 	private $curlErrorMessage;
 
-    /**
-     * @param resource $curl
-     * @return Mollie_API_Exception_ConnectionError
-     */
-    public static function fromCurlFailure($curl)
-    {
-        $e = new static("Unable to communicate with Mollie (".curl_errno($curl)."): " . curl_error($curl) . ")");
+	/**
+	 * @param resource $curl
+	 * @return Mollie_API_Exception_ConnectionError
+	 */
+	public static function fromCurlFailure($curl)
+	{
+		$e = new static("Unable to communicate with Mollie (" . curl_errno($curl) . "): " . curl_error($curl) . ".");
 
-        $e->curlErrorCode = curl_errno($curl);
-        $e->curlErrorMessage = curl_error($curl);
+		$e->curlErrorCode = curl_errno($curl);
+		$e->curlErrorMessage = curl_error($curl);
 
-        return $e;
-    }
+		return $e;
+	}
 
-    /**
-     * @return int
-     */
-    public function getCurlErrorCode()
-    {
-        return $this->curlErrorCode;
-    }
+	/**
+	 * @return int
+	 */
+	public function getCurlErrorCode()
+	{
+		return $this->curlErrorCode;
+	}
 
-    /**
-     * @param int $curlErrorCode
-     */
-    public function setCurlErrorCode($curlErrorCode)
-    {
-        $this->curlErrorCode = $curlErrorCode;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCurlErrorMessage()
-    {
-        return $this->curlErrorMessage;
-    }
-
-    /**
-     * @param string $curlErrorMessage
-     */
-    public function setCurlErrorMessage($curlErrorMessage)
-    {
-        $this->curlErrorMessage = $curlErrorMessage;
-    }
+	/**
+	 * @return string
+	 */
+	public function getCurlErrorMessage()
+	{
+		return $this->curlErrorMessage;
+	}
 }

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -64,7 +64,7 @@ class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
     }
 
     /**
-     * @param string $curlErrorCode
+     * @param int $curlErrorCode
      */
     public function setCurlErrorCode($curlErrorCode)
     {
@@ -72,7 +72,7 @@ class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getCurlErrorMessage()
     {
@@ -80,7 +80,7 @@ class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
     }
 
     /**
-     * @param mixed $curlErrorMessage
+     * @param string $curlErrorMessage
      */
     public function setCurlErrorMessage($curlErrorMessage)
     {

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -31,6 +31,52 @@
  */
 class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
 {
-	public $errorCode;
-	public $errorMessage;
+	private $curlErrorCode;
+	private $curlErrorMessage;
+
+    /**
+     * @param resource $curl
+     * @return Mollie_API_Exception_ConnectionError
+     */
+    public static function fromCurlFailure($curl)
+    {
+        $e = new static("Unable to communicate with Mollie (".curl_errno($curl)."): " . curl_error($curl) . ")");
+
+        $e->curlErrorCode = curl_errno($curl);
+        $e->curlErrorMessage = curl_error($curl);
+
+        return $e;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCurlErrorCode()
+    {
+        return $this->curlErrorCode;
+    }
+
+    /**
+     * @param mixed $curlErrorCode
+     */
+    public function setCurlErrorCode($curlErrorCode)
+    {
+        $this->curlErrorCode = $curlErrorCode;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCurlErrorMessage()
+    {
+        return $this->curlErrorMessage;
+    }
+
+    /**
+     * @param mixed $curlErrorMessage
+     */
+    public function setCurlErrorMessage($curlErrorMessage)
+    {
+        $this->curlErrorMessage = $curlErrorMessage;
+    }
 }

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -31,4 +31,6 @@
  */
 class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
 {
+	public $errorCode;
+	public $errorMessage;
 }

--- a/src/Mollie/API/Exception/ConnectionError.php
+++ b/src/Mollie/API/Exception/ConnectionError.php
@@ -31,7 +31,14 @@
  */
 class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
 {
+    /**
+     * @var int
+     */
 	private $curlErrorCode;
+
+    /**
+     * @var string
+     */
 	private $curlErrorMessage;
 
     /**
@@ -49,7 +56,7 @@ class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getCurlErrorCode()
     {
@@ -57,7 +64,7 @@ class Mollie_API_Exception_ConnectionError extends Mollie_API_Exception
     }
 
     /**
-     * @param mixed $curlErrorCode
+     * @param string $curlErrorCode
      */
     public function setCurlErrorCode($curlErrorCode)
     {


### PR DESCRIPTION
# What am I looking at?

This pull request implements a custom exception for use cases in which a cURL error is returned. The exception contains the cURL error code and status message.

# But, why?

These errors were previously returned by the generic `Mollie_API_Exception`. The problem with this is that it's not very easy to distinguish between the different error types. For example, a cURL timeout would result in `error code 28` being returned, but one would have to parse the exception message to determine that this was the actual error.

With this pull request, handling different connection scenarios should be easier.