### PR TITLE
Bump the PHP version to 5.3 fixes #115

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "cbc", "gift cards", "intersolve", "fashioncheque"
     ],
     "require" : {
-        "php": ">=5.2",
+        "php": ">=5.3",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*"


### PR DESCRIPTION
As brought to our attention by @Tjoosten 
We want to bump the composer version to 5.3 as we cannot run the travis ci on 5.2 anymore thus we now only support =>5.3