### PR TITLE
Retry on connection error

### DIFF
--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -314,16 +314,17 @@ class Mollie_API_Client
 	 * @see $payments
 	 * @see $isuers
 	 *
-	 * @param $http_method
-	 * @param $api_method
-	 * @param $http_body
+	 * @param string $http_method
+	 * @param string $api_method
+	 * @param string $http_body
+     * @param int $retries Number of times to retry the HTTP call. Will only be retried if there was a connection error.
 	 *
 	 * @return string
 	 * @throws Mollie_API_Exception
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function performHttpCall ($http_method, $api_method, $http_body = NULL)
+	public function performHttpCall ($http_method, $api_method, $http_body = NULL, $retries = 3)
 	{
 		if (empty($this->api_key))
 		{
@@ -388,12 +389,27 @@ class Mollie_API_Client
 
 		$body = curl_exec($this->ch);
 
-		$this->last_http_response_status_code = (int) curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
+		$this->last_http_response_status_code = (int)curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
 
-		if (curl_errno($this->ch))
-		{
-			$message = "Unable to communicate with Mollie (".curl_errno($this->ch)."): " . curl_error($this->ch) . ".";
+		if (curl_errno($this->ch)) {
 
+			static $connectionErrors = [
+				CURLE_OPERATION_TIMEOUTED => true,
+				CURLE_COULDNT_RESOLVE_HOST => true,
+				CURLE_COULDNT_CONNECT => true,
+				CURLE_SSL_CONNECT_ERROR => true,
+				CURLE_GOT_NOTHING => true,
+			];
+
+			/*
+			 * If there is a connection error, retry (using a fresh connection).
+			 */
+			if (in_array(curl_errno($this->ch), $connectionErrors) && $retries > 0) {
+				$this->closeTcpConnection();
+				return $this->performHttpCall($http_method, $api_method, $http_body, $retries - 1);
+			}
+
+			$message = "Unable to communicate with Mollie (" . curl_errno($this->ch) . "): " . curl_error($this->ch) . ".";
 			$this->closeTcpConnection();
 			throw new Mollie_API_Exception($message);
 		}

--- a/src/Mollie/API/Client.php
+++ b/src/Mollie/API/Client.php
@@ -393,13 +393,13 @@ class Mollie_API_Client
 
 		if (curl_errno($this->ch)) {
 
-			static $connectionErrors = [
+			static $connectionErrors = array(
 				CURLE_OPERATION_TIMEOUTED => true,
 				CURLE_COULDNT_RESOLVE_HOST => true,
 				CURLE_COULDNT_CONNECT => true,
 				CURLE_SSL_CONNECT_ERROR => true,
 				CURLE_GOT_NOTHING => true,
-			];
+			);
 
 			/*
 			 * If there is a connection error, retry (using a fresh connection).


### PR DESCRIPTION
This retries the API call if the connection cannot be established - e.g. if the socket cannot be opened for some reason. So, only if no packets were received by the Mollie API. 