### PR TITLE
Make it so we expect 303 client behaviour when redirecting fixes #119

### DIFF
--- a/examples/01-new-payment.php
+++ b/examples/01-new-payment.php
@@ -48,9 +48,10 @@ try
 	 */
 	database_write($order_id, $payment->status);
 
-	/*
-	 * Send the customer off to complete the payment.
-	 */
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
+     */
 	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)

--- a/examples/01-new-payment.php
+++ b/examples/01-new-payment.php
@@ -51,7 +51,7 @@ try
 	/*
 	 * Send the customer off to complete the payment.
 	 */
-	header("Location: " . $payment->getPaymentUrl());
+	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)
 {

--- a/examples/04-ideal-payment.php
+++ b/examples/04-ideal-payment.php
@@ -77,7 +77,7 @@ try
 	/*
 	 * Send the customer off to complete the payment.
 	 */
-	header("Location: " . $payment->getPaymentUrl());
+	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)
 {

--- a/examples/04-ideal-payment.php
+++ b/examples/04-ideal-payment.php
@@ -74,9 +74,10 @@ try
 	 */
 	database_write($order_id, $payment->status);
 
-	/*
-	 * Send the customer off to complete the payment.
-	 */
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
+     */
 	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)

--- a/examples/10-oauth-new-payment.php
+++ b/examples/10-oauth-new-payment.php
@@ -64,7 +64,7 @@ try
 		return;
 	}
 
-	header("Location: " . $payment->getPaymentUrl());
+	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)
 {

--- a/examples/10-oauth-new-payment.php
+++ b/examples/10-oauth-new-payment.php
@@ -55,9 +55,10 @@ try
 	 */
 	database_write($order_id, $payment->status);
 
-	/*
-	 * Send the customer off to complete the payment.
-	 */
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
+     */
 	if (PHP_SAPI === "cli")
 	{
 		echo "Redirect to: " . $payment->getPaymentUrl() . PHP_EOL;

--- a/examples/12-new-customer-payment.php
+++ b/examples/12-new-customer-payment.php
@@ -49,7 +49,7 @@ try
 	/*
 	 * Send the customer off to complete the payment.
 	 */
-	header("Location: " . $payment->getPaymentUrl());
+	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)
 {

--- a/examples/12-new-customer-payment.php
+++ b/examples/12-new-customer-payment.php
@@ -46,9 +46,10 @@ try
 	 */
 	database_write($order_id, $payment->status);
 
-	/*
-	 * Send the customer off to complete the payment.
-	 */
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
+     */
 	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)

--- a/examples/14-recurring-first-payment.php
+++ b/examples/14-recurring-first-payment.php
@@ -49,8 +49,9 @@ try
 	 */
 	database_write($order_id, $payment->status);
 
-	/*
-	 * Send the customer off to complete the first payment.
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
 	 *
 	 * After completion, the customer will have a pending or valid mandate that can be
 	 * used for recurring payments and subscriptions.

--- a/examples/14-recurring-first-payment.php
+++ b/examples/14-recurring-first-payment.php
@@ -55,7 +55,7 @@ try
 	 * After completion, the customer will have a pending or valid mandate that can be
 	 * used for recurring payments and subscriptions.
 	 */
-	header("Location: " . $payment->getPaymentUrl());
+	header("Location: " . $payment->getPaymentUrl(), true, 303);
 }
 catch (Mollie_API_Exception $e)
 {


### PR DESCRIPTION
We want to make unambiguously clear which kind of http redirect reaction we expect for clients using our examples. So we add http response code 303 to our header locations.

We do this to make sure that when our example is posted upon and then redirects (for example when making a post form with a payment method) we do a GET on the location field-value even when we use a POST as the original request method.

There have been cases that it got treated as 307 and copied the original request method for the redirect. Which can result in failing payments.

See the note on the 302 response: 
https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3