### PR TITLE
Replace IBAN in example that doesent pass checks

### DIFF
--- a/examples/22-create-mandate-subscription.php
+++ b/examples/22-create-mandate-subscription.php
@@ -21,7 +21,7 @@ try
     // create mandate
     $mandate = $mollie->customers_mandates->withParentId($customer->id)->create(array(
         "method" => 'directdebit',
-        "consumerAccount" => 'NL12ABNA654065985',
+        "consumerAccount" => 'NL34ABNA0243341423',
         "consumerName" => 'B. A. Example',
     ));
     echo "<p>Mandate created with id ". $mandate->id."</p>";


### PR DESCRIPTION
The IBAN inside the 22-create-mandate-subscription.php does not pass our API's IBAN checks.
I generated a non-existing IBAN which does pass these checks and added it to our example.

Now it runs without error when used on a test API key.