### PR TITLE
Add canBeCancelled property to Mollie_API_Object_Payment

### DIFF
--- a/src/Mollie/API/Object/Payment.php
+++ b/src/Mollie/API/Object/Payment.php
@@ -258,6 +258,13 @@ class Mollie_API_Object_Payment
 	 */
 	public $links;
 
+    /**
+     * Whether or not the payment can be cancelled.
+     *
+     * @var bool|null
+     */
+	public $canBeCancelled;
+
 	/**
 	 * Is this payment cancelled?
 	 *

--- a/src/Mollie/API/Object/Payment.php
+++ b/src/Mollie/API/Object/Payment.php
@@ -259,7 +259,7 @@ class Mollie_API_Object_Payment
 	public $links;
 
     /**
-     * Whether or not the payment can be cancelled.
+     * Whether or not this payment can be cancelled.
      *
      * @var bool|null
      */

--- a/src/Mollie/API/Object/Payment.php
+++ b/src/Mollie/API/Object/Payment.php
@@ -258,11 +258,11 @@ class Mollie_API_Object_Payment
 	 */
 	public $links;
 
-    /**
-     * Whether or not this payment can be cancelled.
-     *
-     * @var bool|null
-     */
+	/**
+	* Whether or not this payment can be cancelled.
+	*
+	* @var bool|null
+	*/
 	public $canBeCancelled;
 
 	/**


### PR DESCRIPTION
Added this property to the Mollie_API_Object_Payment class to keep it in line with the docs.