### PR TITLE
Improved exceptions

### DIFF
--- a/src/Mollie/API/Exceptions/ApiException.php
+++ b/src/Mollie/API/Exceptions/ApiException.php
@@ -10,6 +10,35 @@ class ApiException extends \Exception
     protected $field;
 
     /**
+     * @var string
+     */
+    protected $documentationUrl;
+
+    /**
+     * @param string          $message
+     * @param int             $code
+     * @param string|null     $field
+     * @param string|null     $documentationUrl
+     * @param \Throwable|null $previous
+     */
+    public function __construct($message = "", $code = 0, $field = null, $documentationUrl = null, \Throwable $previous = null)
+    {
+        if (!empty($field)) {
+            $this->field = (string)$field;
+            $message .= " Field: {$this->field}.";
+        }
+
+        if (!empty($documentationUrl)) {
+            $this->documentationUrl = (string)$documentationUrl;
+            $message .= " Documentation: {$this->documentationUrl}.";
+        }
+
+        parent::__construct($message, $code, $previous);
+
+
+    }
+
+    /**
      * @return string
      */
     public function getField()
@@ -18,10 +47,10 @@ class ApiException extends \Exception
     }
 
     /**
-     * @param string $field
+     * @return string
      */
-    public function setField($field)
+    public function getDocumentationUrl()
     {
-        $this->field = (string)$field;
+        return $this->documentationUrl;
     }
 }

--- a/tests/Mollie/API/CompatibilityCheckerTest.php
+++ b/tests/Mollie/API/CompatibilityCheckerTest.php
@@ -1,11 +1,12 @@
 <?php
+namespace Tests\Mollie\Api;
 
 use Mollie\Api\CompatibilityChecker;
 
-class Mollie_API_CompatibilityCheckerUnitTest extends PHPUnit_Framework_TestCase
+class CompatibilityCheckerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CompatibilityChecker|PHPUnit_Framework_MockObject_MockObject
+     * @var CompatibilityChecker|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $checker;
 
@@ -22,7 +23,7 @@ class Mollie_API_CompatibilityCheckerUnitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Mollie\Api\Exceptions\IncompatiblePlatform
+     * @expectedException \Mollie\Api\Exceptions\IncompatiblePlatform
      * @expectedExceptionCode Mollie\Api\Exceptions\IncompatiblePlatform::INCOMPATIBLE_PHP_VERSION
      */
     public function testCheckCompatibilityThrowsExceptionOnPhpVersion()
@@ -38,7 +39,7 @@ class Mollie_API_CompatibilityCheckerUnitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Mollie\Api\Exceptions\IncompatiblePlatform
+     * @expectedException \Mollie\Api\Exceptions\IncompatiblePlatform
      * @expectedExceptionCode Mollie\Api\Exceptions\IncompatiblePlatform::INCOMPATIBLE_JSON_EXTENSION
      */
     public function testCheckCompatibilityThrowsExceptionOnJsonExtension()

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Tests\Mollie\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
+
+class MollieApiClientTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $guzzleClient;
+
+    /**
+     * @var MollieApiClient
+     */
+    private $mollieApiClient;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->guzzleClient    = $this->createMock(Client::class);
+        $this->mollieApiClient = new MollieApiClient($this->guzzleClient);
+
+        $this->mollieApiClient->setApiKey('test_foobarfoobarfoobarfoobarfoobar');
+    }
+
+    public function testPerformHttpCallReturnsBodyAsObject()
+    {
+        $response = new Response(200, [], '{"resource": "payment"}');
+
+        $this->guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+
+        $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
+
+        $this->assertEquals(
+            (object)['resource' => 'payment'],
+            $parsedResponse
+        );
+    }
+
+    public function testPerformHttpCallCreatesApiExceptionCorrectly()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Error executing API call (422: Unprocessable Entity): Non-existent parameter "recurringType" for this API call. Did you mean: "sequenceType"? Field: recurringType. Documentation: https://www.mollie.com/en/docs/errors.');
+        $this->expectExceptionCode(422);
+
+        $response = new Response(422, [], '{
+            "status": 422,
+            "title": "Unprocessable Entity",
+            "detail": "Non-existent parameter \"recurringType\" for this API call. Did you mean: \"sequenceType\"?",
+            "field": "recurringType",
+            "_links": {
+                "documentation": {
+                    "href": "https://www.mollie.com/en/docs/errors",
+                    "type": "text/html"
+                }
+            }
+        }');
+
+        $this->guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        try {
+            $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
+        } catch (ApiException $e) {
+            $this->assertEquals('recurringType', $e->getField());
+            $this->assertEquals('https://www.mollie.com/en/docs/errors', $e->getDocumentationUrl());
+
+            throw $e;
+        }
+    }
+
+    public function testPerformHttpCallCreatesApiExceptionWithoutFieldAndDocumentationUrl()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Error executing API call (422: Unprocessable Entity): Non-existent parameter "recurringType" for this API call. Did you mean: "sequenceType"?');
+        $this->expectExceptionCode(422);
+
+        $response = new Response(422, [], '{
+            "status": 422,
+            "title": "Unprocessable Entity",
+            "detail": "Non-existent parameter \"recurringType\" for this API call. Did you mean: \"sequenceType\"?"
+        }');
+
+        $this->guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        try {
+            $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
+        } catch (ApiException $e) {
+            $this->assertNull($e->getField());
+            $this->assertNull($e->getDocumentationUrl());
+
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
The created `ApiException` objects used to show a truncated JSON response. This PR parses the error message and creates a nice `ApiException` object.