### PR TITLE
Revoke customer mandate no exception and helper function

### DIFF
--- a/examples/24-revoke-mandate.php
+++ b/examples/24-revoke-mandate.php
@@ -1,0 +1,31 @@
+<?php
+/*
+Example 24 - Revoke a customer mandate
+*/
+
+try {
+    /*
+     * Initialize the Mollie API library with your API key or OAuth access token.
+     */
+    require "initialize.php";
+
+    /*
+     * Retrieve an existing customer by his customerId
+     */
+    $customer = $mollie->customers->get("cst_cUa8HjKBus");
+
+    /*
+     * Retrieve an existing mandate by his mandateId
+     */
+    $mandate = $customer->getMandate("mdt_pa3s7rGnrC");
+
+    /*
+     * Revoke the mandate
+     */
+    $mandate->revoke();
+
+    echo "<p>Mandate has been successfully revoked.</p>";
+
+} catch (\Mollie\Api\Exceptions\ApiException $e) {
+    echo "API call failed: " . htmlspecialchars($e->getMessage());
+}

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -45,6 +45,11 @@ class MollieApiClient
     const HTTP_DELETE = "DELETE";
 
     /**
+     * HTTP status codes
+     */
+    const HTTP_NO_CONTENT = 204;
+
+    /**
      * @var ClientInterface
      */
     protected $httpClient;
@@ -264,7 +269,7 @@ class MollieApiClient
      * @param string $url
      * @param string|null|resource|StreamInterface $httpBody
      *
-     * @return object
+     * @return object|null
      * @throws ApiException
      *
      * @codeCoverageIgnore
@@ -310,13 +315,18 @@ class MollieApiClient
      * Parse the PSR-7 Response body
      *
      * @param ResponseInterface $response
-     * @return object
+     * @return object|null
      * @throws ApiException
      */
     private function parseResponseBody(ResponseInterface $response)
     {
         $body = $response->getBody()->getContents();
         if (empty($body)) {
+
+            if($response->getStatusCode() === self::HTTP_NO_CONTENT) {
+                return null;
+            }
+
             throw new ApiException("No response body found.");
         }
 

--- a/src/Resources/Mandate.php
+++ b/src/Resources/Mandate.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\Api\Resources;
 
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Types\MandateStatus;
 
 class Mandate extends BaseResource
@@ -80,6 +81,22 @@ class Mandate extends BaseResource
     public function isInvalid()
     {
         return $this->status === MandateStatus::STATUS_INVALID;
+    }
+
+    /**
+     * Revoke the mandate
+     *
+     * @return object|null
+     */
+    public function revoke()
+    {
+        if (!isset($this->_links->self->href)) {
+            return $this;
+        }
+
+        $result = $this->client->performHttpCallToFullUrl(MollieApiClient::HTTP_DELETE, $this->_links->self->href);
+
+        return $result;
     }
 
 }


### PR DESCRIPTION
As noticed in #193 

When doing a delete call our API handles this by giving a 204 No Content response.
Which is good, but our API client should not give an exception.

So i decided to return null, an empty response.
I thought about return a true boolean as some kind of confirmation towards the client user.
But i thought it should be in line with the API so i didn't, and handle this as a succeed or throw.