### PR TITLE
Improve return types and make the available endpoints explicit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
         <directory>tests/</directory>
     </testsuite>
     <logging>
-        <log type="junit" target="build/logs/junit-unittests.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit-unittests.xml"/>
     </logging>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
         <directory>tests/</directory>
     </testsuite>
     <logging>
-        <log type="junit" target="build/logs/junit-unittests.xml"/>
+        <log type="junit" target="build/logs/junit-unittests.xml" logIncompleteSkipped="false"/>
     </logging>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/src/Endpoints/CustomerEndpoint.php
+++ b/src/Endpoints/CustomerEndpoint.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\Api\Endpoints;
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\CustomerCollection;
 
@@ -12,7 +13,7 @@ class CustomerEndpoint extends EndpointAbstract
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *
-     * @return \Mollie\Api\Resources\BaseResource
+     * @return Customer
      */
     protected function getResourceObject()
     {
@@ -25,10 +26,70 @@ class CustomerEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return \Mollie\Api\Resources\BaseCollection
+     * @return CustomerCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
         return new CustomerCollection($this->api, $count, $_links);
+    }
+
+    /**
+     * Creates a customer in Mollie.
+     *
+     * @param array $data An array containing details on the customer.
+     * @param array $filters
+     *
+     * @return Customer
+     * @throws ApiException
+     */
+    public function create(array $data = [], array $filters = [])
+    {
+        return $this->rest_create($data, $filters);
+    }
+
+    /**
+     * Retrieve a single customer from Mollie.
+     *
+     * Will throw a ApiException if the customer id is invalid or the resource cannot be found.
+     *
+     * @param string $customerId
+     * @param array $parameters
+     * @return Customer
+     * @throws ApiException
+     */
+    public function get($customerId, array $parameters = [])
+    {
+        return parent::rest_read($customerId, $parameters);
+    }
+
+    /**
+     * Deletes the given Customer.
+     *
+     * Will throw a ApiException if the customer id is invalid or the resource cannot be found.
+     * Returns with HTTP status No Content (204) if successful.
+     *
+     * @param string $customerId
+     *
+     * @return null
+     * @throws ApiException
+     */
+    public function delete($customerId)
+    {
+        return $this->rest_delete($customerId);
+    }
+
+    /**
+     * Retrieves a collection of Customers from Mollie.
+     *
+     * @param string $from The first customer ID you want to include in your list.
+     * @param int $limit
+     * @param array $parameters
+     *
+     * @return CustomerCollection
+     * @throws ApiException
+     */
+    public function page($from = null, $limit = null, array $parameters = [])
+    {
+        return $this->rest_list($from, $limit, $parameters);
     }
 }

--- a/src/Endpoints/CustomerPaymentsEndpoint.php
+++ b/src/Endpoints/CustomerPaymentsEndpoint.php
@@ -14,7 +14,7 @@ class CustomerPaymentsEndpoint extends EndpointAbstract
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *
-     * @return \Mollie\Api\Resources\BaseResource
+     * @return Payment
      */
     protected function getResourceObject()
     {
@@ -27,7 +27,7 @@ class CustomerPaymentsEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return \Mollie\Api\Resources\BaseCollection
+     * @return PaymentCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
@@ -41,13 +41,13 @@ class CustomerPaymentsEndpoint extends EndpointAbstract
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Payment
      */
     public function createFor(Customer $customer, array $options = [], array $filters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::create($options, $filters);
+        return parent::rest_create($options, $filters);
     }
 
     /**
@@ -56,12 +56,12 @@ class CustomerPaymentsEndpoint extends EndpointAbstract
      * @param int $limit
      * @param array $parameters
      *
-     * @return BaseCollection
+     * @return PaymentCollection
      */
     public function listFor(Customer $customer, $from = null, $limit = null, array $parameters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::page($from, $limit, $parameters);
+        return parent::rest_list($from, $limit, $parameters);
     }
 }

--- a/src/Endpoints/EndpointAbstract.php
+++ b/src/Endpoints/EndpointAbstract.php
@@ -62,7 +62,7 @@ abstract class EndpointAbstract
      */
     protected function rest_create($body, array $filters)
     {
-        $encoded = json_encode($body);
+        $encoded = \GuzzleHttp\json_encode($body);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new ApiException("Error encoding parameters into JSON: '" . json_last_error() . "'.");

--- a/src/Endpoints/EndpointAbstract.php
+++ b/src/Endpoints/EndpointAbstract.php
@@ -62,10 +62,10 @@ abstract class EndpointAbstract
      */
     protected function rest_create($body, array $filters)
     {
-        $encoded = \GuzzleHttp\json_encode($body);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new ApiException("Error encoding parameters into JSON: '" . json_last_error() . "'.");
+        try {
+            $encoded = \GuzzleHttp\json_encode($body);
+        } catch (\InvalidArgumentException $e) {
+            throw new ApiException("Error encoding parameters into JSON: '" . $e->getMessage() . "'.");
         }
 
         $result = $this->api->performHttpCall(

--- a/src/Endpoints/InvoiceEndpoint.php
+++ b/src/Endpoints/InvoiceEndpoint.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\Api\Endpoints;
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Invoice;
 use Mollie\Api\Resources\InvoiceCollection;
 
@@ -33,14 +34,45 @@ class InvoiceEndpoint extends EndpointAbstract
     }
 
     /**
-     * @param null $from
-     * @param null $limit
+     * Retrieve an Invoice from Mollie.
+     *
+     * Will throw a ApiException if the invoice id is invalid or the resource cannot be found.
+     *
+     * @param string $invoiceId
+     * @param array $parameters
+     *
+     * @return Invoice
+     * @throws ApiException
+     */
+    public function get($invoiceId, array $parameters = [])
+    {
+        return $this->rest_read($invoiceId, $parameters);
+    }
+
+    /**
+     * Retrieves a collection of Invoices from Mollie.
+     *
+     * @param string $from The first invoice ID you want to include in your list.
+     * @param int $limit
+     * @param array $parameters
+     *
+     * @return InvoiceCollection
+     * @throws ApiException
+     */
+    public function page($from = null, $limit = null, array $parameters = [])
+    {
+        return $this->rest_list($from, $limit, $parameters);
+    }
+
+    /**
+     * This is a wrapper method for page
+     *
      * @param array|null $parameters
      *
      * @return \Mollie\Api\Resources\BaseCollection
      */
-    public function all($from = null, $limit = null, array $parameters = [])
+    public function all(array $parameters = [])
     {
-        return $this->page($from, $limit, $parameters);
+        return $this->page( null, null, $parameters);
     }
 }

--- a/src/Endpoints/MandateEndpoint.php
+++ b/src/Endpoints/MandateEndpoint.php
@@ -14,7 +14,7 @@ class MandateEndpoint extends EndpointAbstract
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *
-     * @return \Mollie\Api\Resources\BaseResource
+     * @return Mandate
      */
     protected function getResourceObject()
     {
@@ -27,7 +27,7 @@ class MandateEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return \Mollie\Api\Resources\BaseCollection
+     * @return MandateCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
@@ -39,13 +39,13 @@ class MandateEndpoint extends EndpointAbstract
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Mandate
      */
     public function createFor(Customer $customer, array $options = [], array $filters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::create($options, $filters);
+        return parent::rest_create($options, $filters);
     }
 
     /**
@@ -53,13 +53,13 @@ class MandateEndpoint extends EndpointAbstract
      * @param string $mandateId
      * @param array $parameters
      *
-     * @return object
+     * @return Mandate
      */
     public function getFor(Customer $customer, $mandateId, array $parameters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::get($mandateId, $parameters);
+        return parent::rest_read($mandateId, $parameters);
     }
 
     /**
@@ -68,25 +68,25 @@ class MandateEndpoint extends EndpointAbstract
      * @param int $limit
      * @param array $parameters
      *
-     * @return BaseCollection
+     * @return MandateCollection
      */
     public function listFor(Customer $customer, $from = null, $limit = null, array $parameters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::page($from, $limit, $parameters);
+        return parent::rest_list($from, $limit, $parameters);
     }
 
     /**
      * @param Customer $customer
      * @param string $mandateId
      *
-     * @return object
+     * @return null
      */
     public function revokeFor(Customer $customer, $mandateId)
     {
         $this->parentId = $customer->id;
 
-        return parent::delete($mandateId);
+        return parent::rest_delete($mandateId);
     }
 }

--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -3,7 +3,6 @@
 namespace Mollie\Api\Endpoints;
 
 use Mollie\Api\Exceptions\ApiException;
-use Mollie\Api\Resources\BaseCollection;
 use Mollie\Api\Resources\Method;
 use Mollie\Api\Resources\MethodCollection;
 
@@ -25,7 +24,7 @@ class MethodEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return BaseCollection
+     * @return MethodCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
@@ -48,7 +47,7 @@ class MethodEndpoint extends EndpointAbstract
             throw new ApiException("Method ID is empty.");
         }
 
-        return parent::get($methodId, $parameters);
+        return parent::rest_read($methodId, $parameters);
     }
 
     /**
@@ -61,6 +60,6 @@ class MethodEndpoint extends EndpointAbstract
      */
     public function all(array $parameters = [])
     {
-        return parent::page(null, null, $parameters);
+        return parent::rest_list(null, null, $parameters);
     }
 }

--- a/src/Endpoints/PaymentEndpoint.php
+++ b/src/Endpoints/PaymentEndpoint.php
@@ -27,6 +27,33 @@ class PaymentEndpoint extends EndpointAbstract
     }
 
     /**
+     * Get the collection object that is used by this API endpoint. Every API endpoint uses one type of collection object.
+     *
+     * @param int $count
+     * @param object[] $_links
+     *
+     * @return PaymentCollection
+     */
+    protected function getResourceCollectionObject($count, $_links)
+    {
+        return new PaymentCollection($this->api, $count, $_links);
+    }
+
+    /**
+     * Creates a payment in Mollie.
+     *
+     * @param array $data An array containing details on the payment.
+     * @param array $filters
+     *
+     * @return Payment
+     * @throws ApiException
+     */
+    public function create(array $data = [], array $filters = [])
+    {
+        return $this->rest_create($data, $filters);
+    }
+
+    /**
      * Retrieve a single payment from Mollie.
      *
      * Will throw a ApiException if the payment id is invalid or the resource cannot be found.
@@ -42,7 +69,54 @@ class PaymentEndpoint extends EndpointAbstract
             throw new ApiException("Invalid payment ID: '{$paymentId}'. A payment ID should start with '" . self::RESOURCE_ID_PREFIX . "'.");
         }
 
-        return parent::get($paymentId, $parameters);
+        return parent::rest_read($paymentId, $parameters);
+    }
+
+    /**
+     * Deletes the given Payment.
+     *
+     * Will throw a ApiException if the payment id is invalid or the resource cannot be found.
+     * Returns with HTTP status No Content (204) if successful.
+     *
+     * @param string $paymentId
+     *
+     * @return null
+     * @throws ApiException
+     */
+    public function delete($paymentId)
+    {
+        return $this->rest_delete($paymentId);
+    }
+
+    /**
+     * Cancel the given Payment. This is just an alias of the 'delete' method.
+     *
+     * Will throw a ApiException if the payment id is invalid or the resource cannot be found.
+     * Returns with HTTP status No Content (204) if successful.
+     *
+     * @param string $paymentId
+     *
+     * @return null
+     * @throws ApiException
+     */
+    public function cancel($paymentId)
+    {
+        return $this->rest_delete($paymentId);
+    }
+
+    /**
+     * Retrieves a collection of Payments from Mollie.
+     *
+     * @param string $from The first payment ID you want to include in your list.
+     * @param int $limit
+     * @param array $parameters
+     *
+     * @return PaymentCollection
+     * @throws ApiException
+     */
+    public function page($from = null, $limit = null, array $parameters = [])
+    {
+        return $this->rest_list($from, $limit, $parameters);
     }
 
     /**
@@ -54,7 +128,7 @@ class PaymentEndpoint extends EndpointAbstract
      * @param Payment $payment
      * @param array|float|null $data
      *
-     * @return object
+     * @return Refund
      * @throws ApiException
      */
     public function refund(Payment $payment, $data = [])
@@ -69,31 +143,5 @@ class PaymentEndpoint extends EndpointAbstract
         $result = $this->api->performHttpCall(self::REST_CREATE, $resource, $body);
 
         return ResourceFactory::createFromApiResult($result, new Refund($this->api));
-    }
-
-    /**
-     * Cancel the given Payment. This is just an alias of the 'delete' method.
-     *
-     * @param string $paymentId
-     *
-     * @return Payment
-     * @throws ApiException
-     */
-    public function cancel($paymentId)
-    {
-        return $this->delete($paymentId);
-    }
-
-    /**
-     * Get the collection object that is used by this API endpoint. Every API endpoint uses one type of collection object.
-     *
-     * @param int $count
-     * @param object[] $_links
-     *
-     * @return BaseCollection
-     */
-    protected function getResourceCollectionObject($count, $_links)
-    {
-        return new PaymentCollection($this->api, $count, $_links);
     }
 }

--- a/src/Endpoints/ProfileEndpoint.php
+++ b/src/Endpoints/ProfileEndpoint.php
@@ -2,20 +2,18 @@
 
 namespace Mollie\Api\Endpoints;
 
-use Mollie\Api\Resources\BaseCollection;
-use Mollie\Api\Resources\BaseResource;
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Profile;
 use Mollie\Api\Resources\ProfileCollection;
 
 class ProfileEndpoint extends EndpointAbstract
 {
-
     protected $resourcePath = "profiles";
 
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *
-     * @return BaseResource
+     * @return Profile
      */
     protected function getResourceObject()
     {
@@ -28,10 +26,73 @@ class ProfileEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return BaseCollection
+     * @return ProfileCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
         return new ProfileCollection($this->api, $count, $_links);
     }
+
+    /**
+     * Creates a Profile in Mollie.
+     *
+     * @param array $data An array containing details on the profile.
+     * @param array $filters
+     *
+     * @return Profile
+     * @throws ApiException
+     */
+    public function create(array $data = [], array $filters = [])
+    {
+       return $this->rest_create($data, $filters);
+    }
+
+    /**
+     * Retrieve a Profile from Mollie.
+     *
+     * Will throw a ApiException if the profile id is invalid or the resource cannot be found.
+     *
+     * @param string $profileId
+     * @param array $parameters
+     *
+     * @return Profile
+     * @throws ApiException
+     */
+    public function get($profileId, array $parameters = [])
+    {
+        return $this->rest_read($profileId, $parameters);
+    }
+
+    /**
+     * Delete a Profile from Mollie.
+     *
+     * Will throw a ApiException if the profile id is invalid or the resource cannot be found.
+     * Returns with HTTP status No Content (204) if successful.
+     *
+     * @param string $profileId
+     *
+     * @return Profile
+     * @throws ApiException
+     */
+    public function delete($profileId)
+    {
+        return $this->rest_delete($profileId);
+    }
+
+    /**
+     * Retrieves a collection of Profiles from Mollie.
+     *
+     * @param string $from The first profile ID you want to include in your list.
+     * @param int $limit
+     * @param array $parameters
+     *
+     * @return ProfileCollection
+     * @throws ApiException
+     */
+    public function page($from = null, $limit = null, array $parameters = [])
+    {
+        return $this->rest_list($from, $limit, $parameters);
+    }
+
+
 }

--- a/src/Endpoints/SettlementsEndpoint.php
+++ b/src/Endpoints/SettlementsEndpoint.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\Api\Endpoints;
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Settlement;
 use Mollie\Api\Resources\SettlementCollection;
 
@@ -30,5 +31,57 @@ class SettlementsEndpoint extends EndpointAbstract
     protected function getResourceCollectionObject($count, $_links)
     {
         return new SettlementCollection($this->api, $count, $_links);
+    }
+
+    /**
+     * Retrieve a single settlement from Mollie.
+     *
+     * Will throw a ApiException if the settlement id is invalid or the resource cannot be found.
+     *
+     * @param string $settlementId
+     * @param array $parameters
+     * @return Settlement
+     * @throws ApiException
+     */
+    public function get($settlementId, array $parameters = [])
+    {
+         return parent::rest_read($settlementId, $parameters);
+    }
+
+    /**
+     * Retrieve the details of the current settlement that has not yet been paid out.
+     *
+     * @return Settlement
+     * @throws ApiException
+     */
+    public function next()
+    {
+        return parent::rest_read("next", []);
+    }
+
+    /**
+     * Retrieve the details of the open balance of the organization.
+     *
+     * @return Settlement
+     * @throws ApiException
+     */
+    public function open()
+    {
+        return parent::rest_read("open", []);
+    }
+
+    /**
+     * Retrieves a collection of Settlements from Mollie.
+     *
+     * @param string $from The first settlement ID you want to include in your list.
+     * @param int $limit
+     * @param array $parameters
+     *
+     * @return SettlementCollection
+     * @throws ApiException
+     */
+    public function page($from = null, $limit = null, array $parameters = [])
+    {
+        return $this->rest_list($from, $limit, $parameters);
     }
 }

--- a/src/Endpoints/SubscriptionEndpoint.php
+++ b/src/Endpoints/SubscriptionEndpoint.php
@@ -15,7 +15,7 @@ class SubscriptionEndpoint extends EndpointAbstract
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *
-     * @return BaseResource
+     * @return Subscription
      */
     protected function getResourceObject()
     {
@@ -28,7 +28,7 @@ class SubscriptionEndpoint extends EndpointAbstract
      * @param int $count
      * @param object[] $_links
      *
-     * @return BaseCollection
+     * @return SubscriptionCollection
      */
     protected function getResourceCollectionObject($count, $_links)
     {
@@ -42,13 +42,13 @@ class SubscriptionEndpoint extends EndpointAbstract
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Subscription
      */
     public function createFor(Customer $customer, array $options = [], array $filters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::create($options, $filters);
+        return parent::rest_create($options, $filters);
     }
 
     /**
@@ -56,13 +56,13 @@ class SubscriptionEndpoint extends EndpointAbstract
      * @param string $subscriptionId
      * @param array $parameters
      *
-     * @return object
+     * @return Subscription
      */
     public function getFor(Customer $customer, $subscriptionId, array $parameters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::get($subscriptionId, $parameters);
+        return parent::rest_read($subscriptionId, $parameters);
     }
 
     /**
@@ -71,25 +71,25 @@ class SubscriptionEndpoint extends EndpointAbstract
      * @param int $limit
      * @param array $parameters
      *
-     * @return BaseCollection
+     * @return SubscriptionCollection
      */
     public function listFor(Customer $customer, $from = null, $limit = null, array $parameters = [])
     {
         $this->parentId = $customer->id;
 
-        return parent::page($from, $limit, $parameters);
+        return parent::rest_list($from, $limit, $parameters);
     }
 
     /**
      * @param Customer $customer
      * @param string $subscriptionId
      *
-     * @return object
+     * @return null
      */
     public function cancelFor(Customer $customer, $subscriptionId)
     {
         $this->parentId = $customer->id;
 
-        return parent::delete($subscriptionId);
+        return parent::rest_delete($subscriptionId);
     }
 }

--- a/src/Resources/Customer.php
+++ b/src/Resources/Customer.php
@@ -61,7 +61,7 @@ class Customer extends BaseResource
     public $_links;
 
     /**
-     * @return BaseResource
+     * @return Customer
      */
     public function update()
     {
@@ -85,7 +85,7 @@ class Customer extends BaseResource
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Payment
      */
     public function createPayment(array $options = [], array $filters = [])
     {
@@ -94,6 +94,8 @@ class Customer extends BaseResource
 
     /**
      * Get all payments for this customer
+     *
+     * @return PaymentCollection
      */
     public function payments()
     {
@@ -104,7 +106,7 @@ class Customer extends BaseResource
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Subscription
      */
     public function createSubscription(array $options = [], array $filters = [])
     {
@@ -115,7 +117,7 @@ class Customer extends BaseResource
      * @param string $subscriptionId
      * @param array $parameters
      *
-     * @return object
+     * @return Subscription
      */
     public function getSubscription($subscriptionId, array $parameters = [])
     {
@@ -125,7 +127,7 @@ class Customer extends BaseResource
     /**
      * @param string $subscriptionId
      *
-     * @return object
+     * @return null
      */
     public function cancelSubscription($subscriptionId)
     {
@@ -134,6 +136,8 @@ class Customer extends BaseResource
 
     /**
      * Get all subscriptions for this customer
+     *
+     * @return SubscriptionCollection
      */
     public function subscriptions()
     {
@@ -144,7 +148,7 @@ class Customer extends BaseResource
      * @param array $options
      * @param array $filters
      *
-     * @return object
+     * @return Mandate
      */
     public function createMandate(array $options = [], array $filters = [])
     {
@@ -155,7 +159,7 @@ class Customer extends BaseResource
      * @param string $mandateId
      * @param array $parameters
      *
-     * @return object
+     * @return Mandate
      */
     public function getMandate($mandateId, array $parameters = [])
     {
@@ -165,7 +169,7 @@ class Customer extends BaseResource
     /**
      * @param string $mandateId
      *
-     * @return object
+     * @return null
      */
     public function revokeMandate($mandateId)
     {
@@ -174,6 +178,8 @@ class Customer extends BaseResource
 
     /**
      * Get all mandates for this customer
+     *
+     * @return MandateCollection
      */
     public function mandates()
     {

--- a/src/Resources/Mandate.php
+++ b/src/Resources/Mandate.php
@@ -86,7 +86,7 @@ class Mandate extends BaseResource
     /**
      * Revoke the mandate
      *
-     * @return object|null
+     * @return null
      */
     public function revoke()
     {


### PR DESCRIPTION
Changed the return types to the resource object classes.
And made the endpoint calls explicit, since for instance a /methods call only has get and list.
So when calling ``$mollie->methods->`` my IDE does not suggest create or delete.