### PR TITLE
Update link to API keys page

### DIFF
--- a/examples/01-new-payment.php
+++ b/examples/01-new-payment.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
 

--- a/examples/02-webhook-verification.php
+++ b/examples/02-webhook-verification.php
@@ -9,7 +9,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
 

--- a/examples/04-ideal-payment.php
+++ b/examples/04-ideal-payment.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
 

--- a/examples/05-payments-history.php
+++ b/examples/05-payments-history.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
 

--- a/examples/06-list-activated-methods.php
+++ b/examples/06-list-activated-methods.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
     /*

--- a/examples/07-refund-payment.php
+++ b/examples/07-refund-payment.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "./initialize.php";
 

--- a/examples/13-customer-payments-history.php
+++ b/examples/13-customer-payments-history.php
@@ -7,7 +7,7 @@ try {
     /*
      * Initialize the Mollie API library with your API key.
      *
-     * See: https://www.mollie.com/dashboard/settings/profiles
+     * See: https://www.mollie.com/dashboard/developers/api-keys
      */
     require "initialize.php";
 

--- a/examples/initialize.php
+++ b/examples/initialize.php
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../vendor/autoload.php";
 /*
  * Initialize the Mollie API library with your API key.
  *
- * See: https://www.mollie.com/dashboard/settings/profiles
+ * See: https://www.mollie.com/dashboard/developers/api-keys
  */
 $mollie = new \Mollie\Api\MollieApiClient();
 $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");


### PR DESCRIPTION
We've moved the API keys to a dedicated developers page in the dashboard. Only old merchants will still see a link to the API keys on the profiles page.