### PR TITLE
GuzzleException never thrown in block

### DIFF
--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -309,7 +309,7 @@ class MollieApiClient
 
         try {
             $response = $this->httpClient->send($request, ['http_errors' => false]);
-        } catch (GuzzleException $e) {
+        } catch (\InvalidArgumentException $e) {
             throw new ApiException($e->getMessage(), $e->getCode(), $e);
         }
 


### PR DESCRIPTION
GuzzleException never thrown in block, shouldn't this be: \InvalidArgumentException