### PR TITLE
#23 Isolate dependencies in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/build
 /vendor
 /composer.lock
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
 - vendor/bin/phpunit
 before_deploy:
 - sed -i "/const CLIENT_VERSION/c\\    const CLIENT_VERSION = '${TRAVIS_TAG:1}';" src/MollieApiClient.php
-- composer install --no-dev --no-scripts --no-suggest --classmap-authoritative
-- zip -r mollie-api-php.zip examples src vendor composer.json LICENSE README.md
+- composer global require humbug/php-scoper
+- make mollie-api-php.zip
 deploy:
   provider: releases
   api_key:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+#
+# This automatically creates a fresh build for distribution with other modules or for getting started with Mollie
+# without composer.
+#
+mollie-api-php.zip:
+	#
+	# First, install all dependencies. Then prefix everything with humbug/php-scoper. Finally, we should dump the
+	# autoloader again to update the autoloader with the new classnames.
+	#
+	composer install --no-dev --no-scripts --no-suggest
+	$(shell composer global config bin-dir --absolute)/php-scoper add-prefix --force
+	composer dump-autoload --working-dir build --classmap-authoritative
+
+	#
+	# Now move the autoload files. We have to use the scoper one to load the aliasses but we want to load the normal
+	# filename. Flip them around.
+	#
+	mv build/vendor/autoload.php build/vendor/composer-autoload.php
+	sed -i 's/autoload.php/composer-autoload.php/g' build/vendor/scoper-autoload.php
+	mv build/vendor/scoper-autoload.php build/vendor/autoload.php
+
+	#
+	# Finally, create a zip file with all built files.
+	#
+	cd build; zip -r ../mollie-api-php.zip examples src vendor composer.json LICENSE README.md

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,1 +1,0 @@
-junit-unittests.xml

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+// scoper.inc.php
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'prefix' => null,                       // string|null
+    'finders' => [],                        // Finder[]
+    'patchers' => [],                       // callable[]
+    'whitelist' => [
+        'Mollie\\Api\\*',
+        'PHPUnit\\Framework\\*',
+        'GuzzleHttp\\ClientInterface',
+    ],
+];


### PR DESCRIPTION
This adds a step where the zip file that is used for releases is special - Mollie's dependencies have been isolated using [humbug/php-scoper](https://github.com/humbug/php-scoper).

An example release has been created using this method: 

[mollie-api-php.zip](https://github.com/mollie/mollie-api-php/files/2202345/mollie-api-php.zip)
