### PR TITLE
Abstract the Guzzle dependency to a HttpClient implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.github
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/Makefile
 /phpunit.xml export-ignore
 /scoper.inc.php export-ignore

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ To use the Mollie API client, the following things are required:
 
 ## Composer Installation ##
 
-By far the easiest way to install the Mollie API client is to require it with [Composer](http://getcomposer.org/doc/00-intro.md).
+By far the easiest way to install the Mollie API client is to require it with [Composer](http://getcomposer.org/doc/00-intro.md).  
 
-    $ composer require mollie/mollie-api-php:^2.0
+The Mollie client depends on a ``php-http/client-implementation`` so make sure to install a package providing that.
+We suggest using ``php-http/guzzle6-adapter``.
+
+    $ composer require mollie/mollie-api-php:^2.0 php-http/guzzle6-adapter:^1.0
 
     {
         "require": {
-            "mollie/mollie-api-php": "^2.0"
+            "mollie/mollie-api-php": "^2.0",
+            "php-http/guzzle6-adapter": "^1.0"
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To use the Mollie API client, the following things are required:
 + Follow [a few steps](https://www.mollie.com/dashboard/?modal=onboarding) to enable payment methods in live mode, and let us handle the rest.
 + PHP >= 5.6
 + Up-to-date OpenSSL (or other SSL/TLS toolkit)
++ An HTTP client which implements the ``php-http/client-implementation``. You can find the available implementations [here](https://packagist.org/providers/php-http/client-implementation). We recommend ``php-http/guzzle6-adapter``.
 
 ## Composer Installation ##
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Mollie client depends on a ``php-http/client-implementation`` so make sure t
 We suggest using ``php-http/guzzle6-adapter``.
 
 ```console
-$ composer require mollie/mollie-api-php:^2.0 php-http/guzzle6-adapter:^1.0
+$ composer require mollie/mollie-api-php:^2.1 php-http/guzzle6-adapter:^1.0
 ```
 
 The version of the API client corresponds to the version of the API it implements. Check the [notes on migration](https://docs.mollie.com/migrating-v1-to-v2) to see what changes you need to make if you want to start using a newer API version.

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,18 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-openssl": "*",
-    "guzzlehttp/guzzle": "^6.3"
+    "psr/http-message": "^1.0",
+    "php-http/client-implementation": "^1.0",
+    "php-http/discovery": "^1.0",
+    "php-http/message-factory": "^1.0"
+
   },
   "require-dev": {
+    "eloquent/liberator": "^2.0",
     "phpunit/phpunit": "^5.7|^6.5|^7.1",
-    "eloquent/liberator": "^2.0"
+    "php-http/mock-client": "^1.1",
+    "php-http/message": "^1.6",
+    "guzzlehttp/psr7": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Endpoints/EndpointAbstract.php
+++ b/src/Endpoints/EndpointAbstract.php
@@ -63,7 +63,7 @@ abstract class EndpointAbstract
     protected function rest_create($body, array $filters)
     {
         try {
-            $encoded = \GuzzleHttp\json_encode($body);
+            $encoded = json_encode($body);
         } catch (\InvalidArgumentException $e) {
             throw new ApiException("Error encoding parameters into JSON: '" . $e->getMessage() . "'.");
         }

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -26,7 +26,7 @@ class MollieApiClient
     /**
      * Version of our client.
      */
-    const CLIENT_VERSION = "2.0.5";
+    const CLIENT_VERSION = "2.0.6";
 
     /**
      * Endpoint of the remote API.

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -402,7 +402,7 @@ class MollieApiClient
      */
     public function __sleep()
     {
-        return ["apiEndpoint", "httpClient"];
+        return ["apiEndpoint"];
     }
 
     /**
@@ -415,6 +415,6 @@ class MollieApiClient
      */
     public function __wakeup()
     {
-        $this->__construct($this->httpClient);
+        $this->__construct();
     }
 }

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -163,12 +163,17 @@ class MollieApiClient
      */
     public function __construct(HttpClient $httpClient = null, RequestFactory $requestFactory = null)
     {
-
         try {
             $this->httpClient = $httpClient ? $httpClient : HttpClientDiscovery::find();
             $this->requestFactory = $requestFactory ? $requestFactory : MessageFactoryDiscovery::find();
-        } catch (Exception $e) {
-            throw new IncompatiblePlatform('We could not find any http-client-implementation. Install a package providing "php-http/client-implementation". Example: "php-http/guzzle6-adapter".');
+        } catch (Exception\NotFoundException $e) {
+            throw new IncompatiblePlatform(
+                'We could not find any http-client-implementation. Install a package providing "php-http/client-implementation". Example: "composer install php-http/guzzle6-adapter".'
+            );
+        } catch (Exception\DiscoveryFailedException $e) {
+            throw new IncompatiblePlatform(
+                'We could not find any http client or message factory. Install a package providing "php-http/client-implementation" and a PSR7 message implementation. Example: "composer install php-http/guzzle6-adapter".'
+            );
         }
 
         $compatibilityChecker = new CompatibilityChecker();
@@ -381,7 +386,7 @@ class MollieApiClient
 
         return $object;
     }
-    
+
     /**
      * Serialization can be used for caching. Of course doing so can be dangerous but some like to live dangerously.
      *

--- a/tests/Mollie/API/Endpoints/BaseEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/BaseEndpointTest.php
@@ -24,11 +24,6 @@ abstract class BaseEndpointTest extends \PHPUnit\Framework\TestCase
      */
     protected $apiClient;
 
-    protected function setUp()
-    {
-        parent::setUp();
-    }
-
     protected function mockApiCall(Response $response)
     {
         $this->httpClient = new Client();

--- a/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
@@ -13,12 +13,6 @@ class ChargebackEndpointTest extends BaseEndpointTest
     public function testGetChargebacksOnPaymentResource()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/payments/tr_44aKxzEbr8/chargebacks",
-                [],
-                ''
-            ),
             new Response(
                 201,
                 [],
@@ -91,6 +85,13 @@ class ChargebackEndpointTest extends BaseEndpointTest
         );
 
         $chargebacks = $this->getPayment()->chargebacks();
+
+        $this->assertRequest(new Request(
+            "GET",
+            "https://api.mollie.com/v2/payments/tr_44aKxzEbr8/chargebacks",
+            [],
+            ''
+        ));
 
         $this->assertInstanceOf(ChargebackCollection::class, $chargebacks);
         $this->assertEquals(2, $chargebacks->count);

--- a/tests/Mollie/API/Endpoints/CustomerEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/CustomerEndpointTest.php
@@ -12,7 +12,6 @@ class CustomerEndpointTest extends BaseEndpointTest
     public function testCreateWorks()
     {
         $this->mockApiCall(
-            new Request('POST', '/v2/customers'),
             new Response(
                 200,
                 [],
@@ -42,6 +41,11 @@ class CustomerEndpointTest extends BaseEndpointTest
             "email" => "johndoe@example.org"
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/customers'
+        ));
+
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals("customer", $customer->resource);
         $this->assertEquals("cst_FhQJRw4s2n", $customer->id);
@@ -60,7 +64,6 @@ class CustomerEndpointTest extends BaseEndpointTest
     public function testGetWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers/cst_FhQJRw4s2n'),
             new Response(
                 200,
                 [],
@@ -87,6 +90,11 @@ class CustomerEndpointTest extends BaseEndpointTest
         /** @var Customer $customer */
         $customer = $this->apiClient->customers->get("cst_FhQJRw4s2n");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n'
+        ));
+
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals("customer", $customer->resource);
         $this->assertEquals("cst_FhQJRw4s2n", $customer->id);
@@ -105,7 +113,6 @@ class CustomerEndpointTest extends BaseEndpointTest
     public function testListWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers'),
             new Response(
                 200,
                 [],
@@ -144,6 +151,11 @@ class CustomerEndpointTest extends BaseEndpointTest
 
         /** @var Customer $customer */
         $customers = $this->apiClient->customers->page();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers'
+        ));
 
         $this->assertInstanceOf(CustomerCollection::class, $customers);
 

--- a/tests/Mollie/API/Endpoints/CustomerPaymentEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/CustomerPaymentEndpointTest.php
@@ -16,23 +16,6 @@ class CustomerPaymentEndpointTest extends BaseEndpointTest
     public function testCreateCustomerPayment()
     {
         $this->mockApiCall(
-            new Request(
-                "POST",
-                "/v2/customers/cst_FhQJRw4s2n/payments",
-                [],
-                '{
-                    "amount":{  
-                      "value":"20.00",
-                      "currency":"EUR"
-                    },
-                    "description": "My first API payment",
-                    "redirectUrl": "https://example.org/redirect",
-                    "webhookUrl": "https://example.org/webhook",
-                    "metadata": {
-                        "order_id": "1234"
-                    }
-                }'
-            ),
             new Response(
                 201,
                 [],
@@ -95,6 +78,24 @@ class CustomerPaymentEndpointTest extends BaseEndpointTest
             ],
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/payments',
+            [],
+            '{
+                    "amount":{  
+                      "value":"20.00",
+                      "currency":"EUR"
+                    },
+                    "description": "My first API payment",
+                    "redirectUrl": "https://example.org/redirect",
+                    "webhookUrl": "https://example.org/webhook",
+                    "metadata": {
+                        "order_id": "1234"
+                    }
+                }'
+        ));
+
         $this->assertInstanceOf(Payment::class, $payment);
         $this->assertEquals('tr_44aKxzEbr8', $payment->id);
         $this->assertEquals('test', $payment->mode);
@@ -133,12 +134,6 @@ class CustomerPaymentEndpointTest extends BaseEndpointTest
     public function testListCustomerPayments()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/customers/cst_FhQJRw4s2n/payments",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -273,6 +268,11 @@ class CustomerPaymentEndpointTest extends BaseEndpointTest
         $customer = $this->getCustomer();
 
         $payments = $customer->payments();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/payments'
+        ));
 
         $this->assertInstanceOf(PaymentCollection::class, $payments);
         $this->assertEquals(3, $payments->count);

--- a/tests/Mollie/API/Endpoints/InvoiceEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/InvoiceEndpointTest.php
@@ -13,12 +13,6 @@ class InvoiceEndpointTest extends BaseEndpointTest
     public function testGetInvoice()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/invoices/inv_bsa6PvAwaK",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -84,6 +78,11 @@ class InvoiceEndpointTest extends BaseEndpointTest
 
         $invoice = $this->apiClient->invoices->get("inv_bsa6PvAwaK");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/invoices/inv_bsa6PvAwaK'
+        ));
+
         $this->assertInstanceOf(Invoice::class, $invoice);
         $this->assertEquals("invoice", $invoice->resource);
         $this->assertEquals("inv_bsa6PvAwaK", $invoice->id);
@@ -112,12 +111,6 @@ class InvoiceEndpointTest extends BaseEndpointTest
     public function testListInvoices()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/invoices",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -201,6 +194,13 @@ class InvoiceEndpointTest extends BaseEndpointTest
         );
 
         $invoices = $this->apiClient->invoices->page();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/invoices'
+        ));
+
+
         $this->assertInstanceOf(InvoiceCollection::class, $invoices);
 
         $documentationLink = (object)['href' => 'https://docs.mollie.com/reference/v2/invoices-api/list-invoices', 'type' => 'text/html'];

--- a/tests/Mollie/API/Endpoints/MandateEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MandateEndpointTest.php
@@ -16,7 +16,6 @@ class MandateEndpointTest extends BaseEndpointTest
     public function testCreateWorks()
     {
         $this->mockApiCall(
-            new Request('POST', '/v2/customers/cst_FhQJRw4s2n/mandates'),
             new Response(
                 200,
                 [],
@@ -61,6 +60,11 @@ class MandateEndpointTest extends BaseEndpointTest
             "consumerAccount" => "NL55INGB0000000000"
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/mandates'
+        ));
+
         $this->assertInstanceOf(Mandate::class, $mandate);
         $this->assertEquals("mandate", $mandate->resource);
         $this->assertEquals(MandateStatus::STATUS_VALID, $mandate->status);
@@ -83,7 +87,6 @@ class MandateEndpointTest extends BaseEndpointTest
     public function testGetWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers/cst_FhQJRw4s2n/mandates/mdt_AcQl5fdL4h'),
             new Response(
                 200,
                 [],
@@ -123,6 +126,11 @@ class MandateEndpointTest extends BaseEndpointTest
         /** @var Mandate $mandate */
         $mandate = $customer->getMandate("mdt_AcQl5fdL4h");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/mandates/mdt_AcQl5fdL4h'
+        ));
+
         $this->assertInstanceOf(Mandate::class, $mandate);
         $this->assertEquals("mandate", $mandate->resource);
         $this->assertEquals(MandateStatus::STATUS_VALID, $mandate->status);
@@ -145,7 +153,6 @@ class MandateEndpointTest extends BaseEndpointTest
     public function testListWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers/cst_FhQJRw4s2n/mandates'),
             new Response(
                 200,
                 [],
@@ -199,6 +206,12 @@ class MandateEndpointTest extends BaseEndpointTest
 
         /** @var Mandate $mandate */
         $mandates = $customer->mandates();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/mandates'
+        ));
+
         $this->assertInstanceOf(MandateCollection::class, $mandates);
 
         foreach ($mandates as $mandate) {

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -15,7 +15,6 @@ class MethodEndpointTest extends BaseEndpointTest
     public function testGetMethod()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods/ideal'),
             new Response(
                 200,
                 [],
@@ -43,6 +42,11 @@ class MethodEndpointTest extends BaseEndpointTest
 
         $idealMethod = $this->apiClient->methods->get('ideal');
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/methods/ideal'
+        ));
+
         $this->assertInstanceOf(Method::class, $idealMethod);
         $this->assertEquals('ideal', $idealMethod->id);
         $this->assertEquals('iDEAL', $idealMethod->description);
@@ -66,7 +70,6 @@ class MethodEndpointTest extends BaseEndpointTest
     public function testGetMethodWithIncludeIssuers()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods/ideal?include=issuers'),
             new Response(
                 200,
                 [],
@@ -106,6 +109,11 @@ class MethodEndpointTest extends BaseEndpointTest
         );
 
         $idealMethod = $this->apiClient->methods->get('ideal', ['include' => 'issuers']);
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/methods/ideal?include=issuers'
+        ));
 
         $this->assertInstanceOf(Method::class, $idealMethod);
         $this->assertEquals('ideal', $idealMethod->id);
@@ -148,7 +156,6 @@ class MethodEndpointTest extends BaseEndpointTest
     public function testGetTranslatedMethod()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods/sofort?locale=de_DE'),
             new Response(
                 200,
                 [],
@@ -176,6 +183,11 @@ class MethodEndpointTest extends BaseEndpointTest
 
         $method = $this->apiClient->methods->get('sofort', ['locale' => 'de_DE']);
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/methods/sofort?locale=de_DE'
+        ));
+
         $this->assertInstanceOf(Method::class, $method);
         $this->assertEquals('sofort', $method->id);
         $this->assertEquals('SOFORT Überweisung', $method->description);
@@ -201,7 +213,6 @@ class MethodEndpointTest extends BaseEndpointTest
     public function testListMethods()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods'),
             new Response(
                 200,
                 [],
@@ -286,6 +297,11 @@ class MethodEndpointTest extends BaseEndpointTest
         );
 
         $methods = $this->apiClient->methods->all();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/methods'
+        ));
 
         $this->assertInstanceOf(MethodCollection::class, $methods);
         $this->assertEquals(4, $methods->count);

--- a/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
@@ -180,11 +180,11 @@ class PaymentEndpointTest extends BaseEndpointTest
             )
         );
 
-        $payment = $this->apiClient->payments->get("tr_44aKxzEbr8");
+        $payment = $this->apiClient->payments->get("tr_44aKxzEbr8", ["testmode" => true]);
 
         $this->assertRequest(new Request(
             'GET',
-            'https://api.mollie.com/v2/payments/tr_44aKxzEbr8'
+            'https://api.mollie.com/v2/payments/tr_44aKxzEbr8?testmode=true'
         ));
 
         $this->assertInstanceOf(Payment::class, $payment);

--- a/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
@@ -15,23 +15,6 @@ class PaymentEndpointTest extends BaseEndpointTest
     public function testCreatePayment()
     {
         $this->mockApiCall(
-            new Request(
-                "POST",
-                "/v2/payments",
-                [],
-                '{
-                    "amount":{  
-                      "value":"20.00",
-                      "currency":"EUR"
-                    },
-                    "description": "My first API payment",
-                    "redirectUrl": "https://example.org/redirect",
-                    "webhookUrl": "https://example.org/webhook",
-                    "metadata": {
-                        "order_id": "1234"
-                    }
-                }'
-            ),
             new Response(
                 201,
                 [],
@@ -88,6 +71,24 @@ class PaymentEndpointTest extends BaseEndpointTest
             ],
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/payments',
+            [],
+            '{
+                    "amount":{  
+                      "value":"20.00",
+                      "currency":"EUR"
+                    },
+                    "description": "My first API payment",
+                    "redirectUrl": "https://example.org/redirect",
+                    "webhookUrl": "https://example.org/webhook",
+                    "metadata": {
+                        "order_id": "1234"
+                    }
+                }'
+        ));
+
         $this->assertInstanceOf(Payment::class, $payment);
         $this->assertEquals('tr_44aKxzEbr8', $payment->id);
         $this->assertEquals('test', $payment->mode);
@@ -123,12 +124,6 @@ class PaymentEndpointTest extends BaseEndpointTest
     public function testGetPayment()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/payments/tr_44aKxzEbr8",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -187,6 +182,11 @@ class PaymentEndpointTest extends BaseEndpointTest
 
         $payment = $this->apiClient->payments->get("tr_44aKxzEbr8");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/payments/tr_44aKxzEbr8'
+        ));
+
         $this->assertInstanceOf(Payment::class, $payment);
         $this->assertEquals('tr_44aKxzEbr8', $payment->id);
         $this->assertEquals('test', $payment->mode);
@@ -234,12 +234,6 @@ class PaymentEndpointTest extends BaseEndpointTest
     public function testListPayment()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/payments?limit=3",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -362,6 +356,11 @@ class PaymentEndpointTest extends BaseEndpointTest
         );
 
         $payments = $this->apiClient->payments->page(null, 3);
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/payments?limit=3'
+        ));
 
         $this->assertInstanceOf(PaymentCollection::class, $payments);
         $this->assertEquals(3, $payments->count);

--- a/tests/Mollie/API/Endpoints/ProfileEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/ProfileEndpointTest.php
@@ -13,12 +13,6 @@ class ProfileEndpointTest extends BaseEndpointTest
     public function testGetProfile()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/profiles/pfl_ahe8z8OPut",
-                [],
-                ''
-            ),
             new Response(
                 201,
                 [],
@@ -68,6 +62,11 @@ class ProfileEndpointTest extends BaseEndpointTest
 
         $profile = $this->apiClient->profiles->get('pfl_ahe8z8OPut');
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/profiles/pfl_ahe8z8OPut'
+        ));
+
         $this->assertInstanceOf(Profile::class, $profile);
         $this->assertEquals("pfl_ahe8z8OPut", $profile->id);
         $this->assertEquals("live", $profile->mode);
@@ -102,12 +101,6 @@ class ProfileEndpointTest extends BaseEndpointTest
     public function testListProfiles()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/profiles",
-                [],
-                ''
-            ),
             new Response(
                 201,
                 [],
@@ -216,6 +209,13 @@ class ProfileEndpointTest extends BaseEndpointTest
         );
 
         $profiles = $this->apiClient->profiles->page();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/profiles'
+        ));
+
+
         $this->assertInstanceOf(ProfileCollection::class, $profiles);
         $this->assertEquals(2, $profiles->count);
 

--- a/tests/Mollie/API/Endpoints/RefundEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/RefundEndpointTest.php
@@ -14,12 +14,6 @@ class RefundEndpointTest extends BaseEndpointTest
     public function testCreateRefund()
     {
         $this->mockApiCall(
-            new Request(
-                "POST",
-                "/v2/payments/tr_44aKxzEbr8/refunds",
-                [],
-                '{"amount":{"currency":"EUR","value":"20.00"}}'
-            ),
             new Response(
                 201,
                 [],
@@ -63,6 +57,13 @@ class RefundEndpointTest extends BaseEndpointTest
             ]
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/payments/tr_44aKxzEbr8/refunds',
+            [],
+            '{"amount":{"currency":"EUR","value":"20.00"}}'
+        ));
+
         $this->assertInstanceOf(Refund::class, $refund);
         $this->assertEquals("re_PsAvxvLsnm", $refund->id);
 
@@ -94,12 +95,6 @@ class RefundEndpointTest extends BaseEndpointTest
     public function testGetRefundsOnPaymentResource()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/payments/tr_44aKxzEbr8/refunds",
-                [],
-                ''
-            ),
             new Response(
                 201,
                 [],
@@ -153,6 +148,11 @@ class RefundEndpointTest extends BaseEndpointTest
 
         $refunds = $this->getPayment()->refunds();
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/payments/tr_44aKxzEbr8/refunds'
+        ));
+
         $this->assertInstanceOf(RefundCollection::class, $refunds);
         $this->assertEquals(1, $refunds->count);
         $this->assertCount(1, $refunds);
@@ -180,12 +180,6 @@ class RefundEndpointTest extends BaseEndpointTest
     public function testListRefunds()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/refunds",
-                [],
-                ''
-            ),
             new Response(
                 201,
                 [],
@@ -238,6 +232,11 @@ class RefundEndpointTest extends BaseEndpointTest
         );
 
         $refunds = $this->apiClient->refunds->page();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/refunds'
+        ));
 
         $this->assertInstanceOf(RefundCollection::class, $refunds);
         $this->assertEquals(1, $refunds->count);

--- a/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
@@ -13,12 +13,6 @@ class SettlementEndpointTest extends BaseEndpointTest
     public function testGetSettlement()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/settlements/stl_xcaSGAHuRt",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -195,6 +189,11 @@ class SettlementEndpointTest extends BaseEndpointTest
         /** @var Settlement $settlement */
         $settlement = $this->apiClient->settlements->get("stl_xcaSGAHuRt");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/settlements/stl_xcaSGAHuRt'
+        ));
+
         $this->assertInstanceOf(Settlement::class, $settlement);
         $this->assertEquals("settlement", $settlement->resource);
         $this->assertEquals("stl_xcaSGAHuRt", $settlement->id);
@@ -223,12 +222,6 @@ class SettlementEndpointTest extends BaseEndpointTest
     public function testListSettlement()
     {
         $this->mockApiCall(
-            new Request(
-                "GET",
-                "/v2/settlements",
-                [],
-                ''
-            ),
             new Response(
                 200,
                 [],
@@ -422,6 +415,12 @@ class SettlementEndpointTest extends BaseEndpointTest
 
         /** @var Settlement $settlement */
         $settlements = $this->apiClient->settlements->page();
+
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/settlements'
+        ));
+
         $this->assertInstanceOf(SettlementCollection::class, $settlements);
 
         $documentationLink = (object)['href' => 'https://docs.mollie.com/reference/v2/settlements-api/list-settlements', 'type' => 'text/html'];

--- a/tests/Mollie/API/Endpoints/SubscriptionEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/SubscriptionEndpointTest.php
@@ -14,7 +14,6 @@ class SubscriptionEndpointTest extends BaseEndpointTest
     public function testCreateWorks()
     {
         $this->mockApiCall(
-            new Request('POST', '/v2/customers/cst_FhQJRw4s2n/subscriptions'),
             new Response(
                 200,
                 [],
@@ -64,6 +63,11 @@ class SubscriptionEndpointTest extends BaseEndpointTest
             "description" => "Order 1234"
         ]);
 
+        $this->assertRequest(new Request(
+            'POST',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/subscriptions'
+        ));
+
         $this->assertInstanceOf(Subscription::class, $subscription);
         $this->assertEquals("subscription", $subscription->resource);
         $this->assertEquals("sub_wByQa6efm6", $subscription->id);
@@ -91,7 +95,6 @@ class SubscriptionEndpointTest extends BaseEndpointTest
     public function testGetWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers/cst_FhQJRw4s2n/subscriptions/sub_wByQa6efm6'),
             new Response(
                 200,
                 [],
@@ -134,6 +137,11 @@ class SubscriptionEndpointTest extends BaseEndpointTest
         /** @var Subscription $subscription */
         $subscription = $customer->getSubscription("sub_wByQa6efm6");
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/subscriptions/sub_wByQa6efm6'
+        ));
+
         $this->assertInstanceOf(Subscription::class, $subscription);
         $this->assertEquals("subscription", $subscription->resource);
         $this->assertEquals("sub_wByQa6efm6", $subscription->id);
@@ -161,7 +169,6 @@ class SubscriptionEndpointTest extends BaseEndpointTest
     public function testListWorks()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/customers/cst_FhQJRw4s2n/subscriptions'),
             new Response(
                 200,
                 [],
@@ -218,6 +225,11 @@ class SubscriptionEndpointTest extends BaseEndpointTest
 
         $subscriptions = $customer->subscriptions();
 
+        $this->assertRequest(new Request(
+            'GET',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/subscriptions'
+        ));
+
         $this->assertInstanceOf(SubscriptionCollection::class, $subscriptions);
 
         $this->assertEquals(count($subscriptions), $subscriptions->count);
@@ -239,7 +251,6 @@ class SubscriptionEndpointTest extends BaseEndpointTest
     public function testCancelWorks()
     {
         $this->mockApiCall(
-            new Request('DELETE', '/v2/customers/cst_FhQJRw4s2n/subscriptions/sub_wByQa6efm6'),
             new Response(
                 200,
                 [],
@@ -282,6 +293,11 @@ class SubscriptionEndpointTest extends BaseEndpointTest
 
         /** @var Subscription $subscription */
         $subscription = $customer->cancelSubscription("sub_wByQa6efm6");
+
+        $this->assertRequest(new Request(
+            'DELETE',
+            'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/subscriptions/sub_wByQa6efm6'
+        ));
 
         $this->assertInstanceOf(Subscription::class, $subscription);
         $this->assertEquals("subscription", $subscription->resource);

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -4,6 +4,8 @@ namespace Tests\Mollie\Api;
 use Eloquent\Liberator\Liberator;
 use GuzzleHttp\Psr7\Response;
 use Http\Client\HttpClient;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Strategy\MockClientStrategy;
 use Http\Mock\Client;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
@@ -25,6 +27,8 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->httpClient    = new Client();
+
+        HttpClientDiscovery::prependStrategy(MockClientStrategy::class);
 
         $this->mollieApiClient = new MollieApiClient($this->httpClient);
 

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -2,18 +2,18 @@
 namespace Tests\Mollie\Api;
 
 use Eloquent\Liberator\Liberator;
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpClient;
+use Http\Mock\Client;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 
 class MollieApiClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var Client
      */
-    private $guzzleClient;
+    private $httpClient;
 
     /**
      * @var MollieApiClient
@@ -24,8 +24,9 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->guzzleClient    = $this->createMock(Client::class);
-        $this->mollieApiClient = new MollieApiClient($this->guzzleClient);
+        $this->httpClient    = new Client();
+
+        $this->mollieApiClient = new MollieApiClient($this->httpClient);
 
         $this->mollieApiClient->setApiKey('test_foobarfoobarfoobarfoobarfoobar');
     }
@@ -34,11 +35,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
     {
         $response = new Response(200, [], '{"resource": "payment"}');
 
-        $this->guzzleClient
-            ->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
-
+        $this->httpClient->addResponse($response);
 
         $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
 
@@ -67,10 +64,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
             }
         }');
 
-        $this->guzzleClient
-            ->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->httpClient->addResponse($response);
 
         try {
             $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
@@ -94,10 +88,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
             "detail": "Non-existent parameter \"recurringType\" for this API call. Did you mean: \"sequenceType\"?"
         }');
 
-        $this->guzzleClient
-            ->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->httpClient->addResponse($response);
 
         try {
             $parsedResponse = $this->mollieApiClient->performHttpCall('GET', '');
@@ -120,7 +111,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
         $client_copy = Liberator::liberate(unserialize($serialized));
 
         $this->assertEmpty($client_copy->apiKey, "API key should not have been remembered");
-        $this->assertInstanceOf(ClientInterface::class, $client_copy->httpClient, "A Guzzle client should have been set.");
+        $this->assertInstanceOf(HttpClient::class, $client_copy->httpClient, "A Guzzle client should have been set.");
         $this->assertNull($client_copy->usesOAuth());
         $this->assertEquals("https://mymollieproxy.local", $client_copy->getApiEndpoint(), "The API endpoint should be remembered");
 

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -111,7 +111,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
         $client_copy = Liberator::liberate(unserialize($serialized));
 
         $this->assertEmpty($client_copy->apiKey, "API key should not have been remembered");
-        $this->assertInstanceOf(HttpClient::class, $client_copy->httpClient, "A Http client implementation should have been set.");
+        $this->assertInstanceOf(HttpClient::class, $client_copy->httpClient, "An Http client implementation should have been set.");
         $this->assertNull($client_copy->usesOAuth());
         $this->assertEquals("https://mymollieproxy.local", $client_copy->getApiEndpoint(), "The API endpoint should be remembered");
 


### PR DESCRIPTION
This will be a BC breaking change. Since the install will now require 2 steps.
Installing the SDK and also installing a HTTP client implementation.

This will not matter for our ZIP file as we can require the Guzzle 6 adapter in the steps.