### PR TITLE
Add invoiceId property to Settlement

### DIFF
--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -59,7 +59,7 @@ class Settlement extends BaseResource
     /**
      * The ID of the invoice on which this settlement is invoiced, if it has been invoiced.
      *
-     * @var string
+     * @var string|null
      */
     public $invoiceId;
 

--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -57,6 +57,13 @@ class Settlement extends BaseResource
     public $periods;
 
     /**
+     * The ID of the invoice on which this settlement is invoiced, if it has been invoiced.
+     *
+     * @var string
+     */
+    public $invoiceId;
+
+    /**
      * @var object[]
      */
     public $_links;

--- a/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
@@ -166,6 +166,7 @@ class SettlementEndpointTest extends BaseEndpointTest
                       }
                     }
                   },
+                  "invoiceId": "inv_VseyTUhJSy",
                   "_links": {
                     "self": {
                       "href": "https://api.mollie.com/v2/settlements/stl_xcaSGAHuRt",
@@ -203,6 +204,7 @@ class SettlementEndpointTest extends BaseEndpointTest
         $this->assertEquals(SettlementStatus::STATUS_PENDING, $settlement->status);
         $this->assertEquals((object) ["value" => "1980.98", "currency" => "EUR"], $settlement->amount);
         $this->assertNotEmpty($settlement->periods);
+        $this->assertEquals("inv_VseyTUhJSy", $settlement->invoiceId);
 
         $selfLink = (object)['href' => 'https://api.mollie.com/v2/settlements/stl_xcaSGAHuRt', 'type' => 'application/hal+json'];
         $this->assertEquals($selfLink, $settlement->_links->self);
@@ -379,6 +381,7 @@ class SettlementEndpointTest extends BaseEndpointTest
                             }
                           }
                         },
+                        "invoiceId": "",
                         "_links": {
                           "self": {
                             "href": "https://api.mollie.com/v2/settlements/stl_xcaSGAHuRt",

--- a/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
@@ -381,7 +381,6 @@ class SettlementEndpointTest extends BaseEndpointTest
                             }
                           }
                         },
-                        "invoiceId": "",
                         "_links": {
                           "self": {
                             "href": "https://api.mollie.com/v2/settlements/stl_xcaSGAHuRt",


### PR DESCRIPTION
As per the [get-settlement docs](https://docs.mollie.com/reference/v2/settlements-api/get-settlement) the invoiceId is present on the settlement object. This commit adds the property to the class, so it can be retrieved via this client.