### PR TITLE
Interval parameter removed

### DIFF
--- a/examples/25-update-subscription.php
+++ b/examples/25-update-subscription.php
@@ -22,7 +22,6 @@ try {
      * Subscription fields that can be updated are described by the link:
      * See https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
      */
-    $subscription->interval = '2 months';
     $subscription->times = 10;
     $subscription->startDate = '2018-12-02'; // Year-month-day
     $subscription->amount = (object)['value' => '12.12', 'currency' => 'EUR'];


### PR DESCRIPTION
Interval parameter removed from the example, because it is not supported, according to current documentation