### PR TITLE
Fix for incorrect reading of body contents

### DIFF
--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -384,7 +384,7 @@ class MollieApiClient
      */
     private function parseResponseBody(ResponseInterface $response)
     {
-        $body = $response->getBody()->getContents();
+        $body = (string) $response->getBody();
         if (empty($body)) {
             if ($response->getStatusCode() === self::HTTP_NO_CONTENT) {
                 return null;


### PR DESCRIPTION
### Bugfix description
This fixes a bug where the MollieApiClient reads the body contents directly from the Guzzle HTTP stream, which causes the body to be empty if any middleware has been used to read the body as well, e.g. for logging requests and responses.

### What

I found out about this issue when we (the devteam I'm in) used this project via the sibling project https://github.com/mollie/laravel-mollie in a Laravel 5.6 project after providing a custom prepared GuzzleClient for it in a service provider.

The MollieApiClient accepts a Guzzle client as its only constructor parameter and since we wanted to log the HTTP requests and responses for a project of ours, we prepared a custom Guzzle HttpClient called the MollieApiHttpClient like so:

```php
class MollieApiHttpClientServiceProvider extends ServiceProvider
{
    public function register()
    {
        $this->app->singleton(MollieApiHttpClient::class, function (Application $app) {
            $handlerStack = HandlerStack::create();

            $logChannel = $app->get('log')->channel('mollie-api');

            $handlerStack->push(
                Middleware::log(
                    $logChannel,
                    new MessageFormatter('REQUEST: {method} {uri} HTTP/{version} {req_body}')
                )
            );

            $handlerStack->push(
                Middleware::log(
                    $logChannel,
                    new MessageFormatter('RESPONSE: {code} - {res_body}')
                )
            );

            $proxy = $app->get('config')->get('proxy', null);

            return new MollieApiHttpClient([
                'handler' => $handlerStack,
                RequestOptions::PROXY => $proxy,
                RequestOptions::VERIFY => CaBundle::getBundledCaBundlePath()
            ]);
        });
    }
}
```

This instance of the Guzzle HttpClient is then fed into the MollieApiClient class, and things break.

### Why does it break?

The problem lies in the way that the MollieApiClient checks for a valid response from the Mollie servers.
This is done by getting the value of `$response->getBody()->getContents()`, which is directly requesting the data from the GuzzleHttp\Psr7\Stream, or to be more specific, any data that's left after the current pointer position.

The problem here is that if any middleware accessed the content body before the response was returned to the MollieApiClient, the pointer of the stream has been moved up to the end, resulting in the situation that the MollieApiClient sees an empty string here and throws an ApiException saying 'No response body found'.

By casting `$response->getBody()` to a string and accessing getBody directly in this way, Guzzle rewinds the body every time with seek(0) (as seen in `GuzzleHttp\Psr7\Stream::__toString()`)  so no issues can occur.

### Strict types?
PHP does some type juggling and converts the remainder of the stream content to a string, because `declare(strict_types=1)` is sadly not (yet) a thing here. When we would switch on strict types here, PHP would break saying that a Stream is being accessed as if it were a string, thus preventing this issue altogether.
I get however that this is not possible currently, as this package supports older versions of PHP up to PHP 5.6.


### How to test
* See the my first commit only adds the test which shows the current issue, and will break.
* See that my second commit fixes the issue so middleware can successfully be used.
