### PR TITLE
Add new 'authorized' payment status for Klarna payments

### DIFF
--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -262,6 +262,16 @@ class Payment extends BaseResource
     }
 
     /**
+     * Is this payment authorized?
+     *
+     * @return bool
+     */
+    public function isAuthorized()
+    {
+        return $this->status === PaymentStatus::STATUS_AUTHORIZED;
+    }
+
+    /**
      * Is this payment paid for?
      *
      * @return bool

--- a/src/Types/PaymentStatus.php
+++ b/src/Types/PaymentStatus.php
@@ -15,6 +15,16 @@ class PaymentStatus
     const STATUS_PENDING = "pending";
 
     /**
+     * The payment is authorized, but captures still need to be created in order to receive the money.
+     *
+     * This is currently only possible for Klarna Pay later and Klarna Slice it. Payments with these payment methods can
+     * only be created with the Orders API. You should create a Shipment to trigger the capture to receive the money.
+     *
+     * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment
+     */
+    const STATUS_AUTHORIZED = "authorized";
+
+    /**
      * The customer has canceled the payment.
      */
     const STATUS_CANCELED = "canceled";

--- a/tests/Mollie/API/Resources/PaymentTest.php
+++ b/tests/Mollie/API/Resources/PaymentTest.php
@@ -29,13 +29,23 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [PaymentStatus::STATUS_PENDING, "isPending", true],
+            [PaymentStatus::STATUS_PENDING, "isAuthorized", false],
             [PaymentStatus::STATUS_PENDING, "isFailed", false],
             [PaymentStatus::STATUS_PENDING, "isOpen", false],
             [PaymentStatus::STATUS_PENDING, "isCanceled", false],
             [PaymentStatus::STATUS_PENDING, "isPaid", false],
             [PaymentStatus::STATUS_PENDING, "isExpired", false],
 
+            [PaymentStatus::STATUS_AUTHORIZED, "isPending", false],
+            [PaymentStatus::STATUS_AUTHORIZED, "isAuthorized", true],
+            [PaymentStatus::STATUS_AUTHORIZED, "isFailed", false],
+            [PaymentStatus::STATUS_AUTHORIZED, "isOpen", false],
+            [PaymentStatus::STATUS_AUTHORIZED, "isCanceled", false],
+            [PaymentStatus::STATUS_AUTHORIZED, "isPaid", false],
+            [PaymentStatus::STATUS_AUTHORIZED, "isExpired", false],
+
             [PaymentStatus::STATUS_FAILED, "isPending", false],
+            [PaymentStatus::STATUS_FAILED, "isAuthorized", false],
             [PaymentStatus::STATUS_FAILED, "isFailed", true],
             [PaymentStatus::STATUS_FAILED, "isOpen", false],
             [PaymentStatus::STATUS_FAILED, "isCanceled", false],
@@ -43,6 +53,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
             [PaymentStatus::STATUS_FAILED, "isExpired", false],
 
             [PaymentStatus::STATUS_OPEN, "isPending", false],
+            [PaymentStatus::STATUS_OPEN, "isAuthorized", false],
             [PaymentStatus::STATUS_OPEN, "isFailed", false],
             [PaymentStatus::STATUS_OPEN, "isOpen", true],
             [PaymentStatus::STATUS_OPEN, "isCanceled", false],
@@ -50,6 +61,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
             [PaymentStatus::STATUS_OPEN, "isExpired", false],
 
             [PaymentStatus::STATUS_CANCELED, "isPending", false],
+            [PaymentStatus::STATUS_CANCELED, "isAuthorized", false],
             [PaymentStatus::STATUS_CANCELED, "isFailed", false],
             [PaymentStatus::STATUS_CANCELED, "isOpen", false],
             [PaymentStatus::STATUS_CANCELED, "isCanceled", true],
@@ -57,6 +69,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
             [PaymentStatus::STATUS_CANCELED, "isExpired", false],
 
             [PaymentStatus::STATUS_EXPIRED, "isPending", false],
+            [PaymentStatus::STATUS_EXPIRED, "isAuthorized", false],
             [PaymentStatus::STATUS_EXPIRED, "isFailed", false],
             [PaymentStatus::STATUS_EXPIRED, "isOpen", false],
             [PaymentStatus::STATUS_EXPIRED, "isCanceled", false],


### PR DESCRIPTION
The `authorized` status is currently only possible for _Klarna Pay later_ and _Klarna Slice it_. Payments with these payment methods can only be created with the [Orders API](https://docs.mollie.com/reference/v2/orders-api/create-order). You should [create a Shipment](https://docs.mollie.com/reference/v2/shipments-api/create-shipment) to trigger the capture to receive the money.