### PR TITLE
Fix Refund ‘cancel’ 204 response handling

### DIFF
--- a/src/Resources/Refund.php
+++ b/src/Resources/Refund.php
@@ -124,17 +124,19 @@ class Refund extends BaseResource
     }
 
     /**
-     * Cancel the refund
+     * Cancel the refund.
+     * Returns null if successful.
      *
-     * @return BaseResource
+     * @return null
+     * @throws ApiException
      */
     public function cancel()
     {
-        $dataResult = $this->client->performHttpCallToFullUrl(
+        $this->client->performHttpCallToFullUrl(
             MollieApiClient::HTTP_DELETE,
             $this->_links->self->href
         );
 
-        return ResourceFactory::createFromApiResult($dataResult, new self($this->client));
+        return null;
     }
 }


### PR DESCRIPTION
When canceling a Refund, the API returns a `204 No Content` response when canceled. Currently, the library tries to create a Refund resource from the `null` response, which causes an exception.

Docs: https://docs.mollie.com/reference/v2/refunds-api/cancel-refund