### PR TITLE
Removed deprecated Junit flag from the PHPUnit configuration XML

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
         <directory>tests/</directory>
     </testsuite>
     <logging>
-        <log type="junit" target="build/logs/junit-unittests.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit-unittests.xml" />
     </logging>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,9 +7,6 @@
     <testsuite name="Unit tests">
         <directory>tests/</directory>
     </testsuite>
-    <logging>
-        <log type="junit" target="build/logs/junit-unittests.xml" />
-    </logging>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src/</directory>


### PR DESCRIPTION
## Improvement description
Removal of a deprecated Junit flag that's no longer supported in PHPUnit 7 and clogs up the output of the tests when running them from PHPStorm.

## What
Whilst I was working on #282 yesterday, I noticed that the tests I ran from PHPStorm would all output the following message:
```
Testing started at 23:37 ...
/usr/bin/php /home/stefan/projects/mollie-api-php/vendor/phpunit/phpunit/phpunit --configuration /home/stefan/projects/mollie-api-php/phpunit.xml /home/stefan/projects/mollie-api-php/tests --teamcity
PHPUnit 7.3.5 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 11:
  - Element 'log', attribute 'logIncompleteSkipped': The attribute 'logIncompleteSkipped' is not allowed.

  Test results may not be as expected.
```
This clogs up the test output as can be seen below:

![output-clogging](https://user-images.githubusercontent.com/1150201/46378594-6a92bf00-c69c-11e8-87b9-3d461036f03a.png)

Turns out that this option is deprecated as of PHPUnit 7 as described here: https://github.com/sebastianbergmann/phpunit/issues/2779 and is mostly an issue for the folks still running Jenkins with the Junit plugin in a project where one or more tests are skipped.

This project A) runs on Travis-CI instead of Jenkins and B) has no skipped tests so we are good without this.

## How to test
* See that despite this change the tests still pass as if nothing was changed, and Travis is still happy.

## Recommendations
* I suspect that this project once was built on Hudson / Jenkins before moving to Travis-CI, and this is the reason for the Junit output to begin with. Therefor I asume it is safe to remove the Junit output altogether now. Please let me know if this is needed, I will push an extra commit with the complete removal of Junit output.