### PR TITLE
Revert to paginated Chargeback LIST

### DIFF
--- a/src/Endpoints/ChargebackEndpoint.php
+++ b/src/Endpoints/ChargebackEndpoint.php
@@ -30,19 +30,21 @@ class ChargebackEndpoint extends EndpointAbstract
      */
     protected function getResourceCollectionObject($count, $_links)
     {
-        return new ChargebackCollection($count, $_links);
+        return new ChargebackCollection($this->client, $count, $_links);
     }
 
     /**
-     * Retrieve all chargebacks.
+     * Retrieves a collection of Chargebacks from Mollie.
      *
+     * @param string $from The first chargeback ID you want to include in your list.
+     * @param int $limit
      * @param array $parameters
      *
      * @return ChargebackCollection
      * @throws ApiException
      */
-    public function all(array $parameters = [])
+    public function page($from = null, $limit = null, array $parameters = [])
     {
-        return parent::rest_list(null, null, $parameters);
+        return $this->rest_list($from, $limit, $parameters);
     }
 }

--- a/src/Endpoints/PaymentChargebackEndpoint.php
+++ b/src/Endpoints/PaymentChargebackEndpoint.php
@@ -30,7 +30,7 @@ class PaymentChargebackEndpoint extends EndpointAbstract
      */
     protected function getResourceCollectionObject($count, $_links)
     {
-        return new ChargebackCollection($count, $_links);
+        return new ChargebackCollection($this->client, $count, $_links);
     }
 
     /**

--- a/src/Resources/ChargebackCollection.php
+++ b/src/Resources/ChargebackCollection.php
@@ -2,7 +2,7 @@
 
 namespace Mollie\Api\Resources;
 
-class ChargebackCollection extends BaseCollection
+class ChargebackCollection extends CursorCollection
 {
     /**
      * @return string

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -505,6 +505,7 @@ class Payment extends BaseResource
         );
 
         $resourceCollection = new ChargebackCollection(
+            $this->client,
             $result->count,
             $result->_links
         );

--- a/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
@@ -101,7 +101,7 @@ class ChargebackEndpointTest extends BaseEndpointTest
             )
         );
 
-        $chargebacks = $this->apiClient->chargebacks->all();
+        $chargebacks = $this->apiClient->chargebacks->page();
 
         $this->assertInstanceOf(ChargebackCollection::class, $chargebacks);
         $this->assertEquals(2, $chargebacks->count);


### PR DESCRIPTION
PR #316 assumed the Chargeback LIST returned a non-paginated response, but the docs appeared to be outdated. This PR reverts to assuming a paginated response.

Also see #315.