### PR TITLE
Settlement::settledAt property

### DIFF
--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -36,6 +36,14 @@ class Settlement extends BaseResource
     public $createdAt;
 
     /**
+     * The date on which the settlement was settled, in ISO 8601 format. When requesting the open settlement or next settlement the return value is null.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $settledAt;
+
+    /**
      * Status of the settlement.
      *
      * @var string

--- a/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/SettlementEndpointTest.php
@@ -27,6 +27,7 @@ class SettlementEndpointTest extends BaseEndpointTest
                   "id": "stl_xcaSGAHuRt",
                   "reference": "1234567.1234.12",
                   "createdAt": "2018-04-30T04:00:02+00:00",
+                  "settledAt": "2018-05-01T04:00:02+00:00",
                   "status": "pending",
                   "amount": {
                     "value": "1980.98",
@@ -201,6 +202,7 @@ class SettlementEndpointTest extends BaseEndpointTest
         $this->assertEquals("stl_xcaSGAHuRt", $settlement->id);
         $this->assertEquals("1234567.1234.12", $settlement->reference);
         $this->assertEquals("2018-04-30T04:00:02+00:00", $settlement->createdAt);
+        $this->assertEquals("2018-05-01T04:00:02+00:00", $settlement->settledAt);
         $this->assertEquals(SettlementStatus::STATUS_PENDING, $settlement->status);
         $this->assertEquals((object) ["value" => "1980.98", "currency" => "EUR"], $settlement->amount);
         $this->assertNotEmpty($settlement->periods);


### PR DESCRIPTION
The current `Settlement` SDK resource does not include the `settledAt` property even though it's provided in the [`GET /settlements/[id]`](https://docs.mollie.com/reference/v2/settlements-api/get-settlement) operation. This PR adds it :)