### PR TITLE
Order payments() helper

### DIFF
--- a/src/Endpoints/OrderPaymentEndpoint.php
+++ b/src/Endpoints/OrderPaymentEndpoint.php
@@ -47,7 +47,7 @@ class OrderPaymentEndpoint extends EndpointAbstract
      * @param array $data An array containing details on the order payment.
      * @param array $filters
      *
-     * @return \Mollie\Api\Resources\BaseResource|\Mollie\Api\Resources\Order
+     * @return \Mollie\Api\Resources\BaseResource|\Mollie\Api\Resources\Payment
      * @throws \Mollie\Api\Exceptions\ApiException
      */
     public function createFor(Order $order, array $data, array $filters = [])

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -452,7 +452,7 @@ class Order extends BaseResource
      * Retrieve the payments for this order.
      * Requires the order to be retrieved using the embed payments parameter.
      *
-     * @return \Mollie\Api\Resources\PaymentCollection
+     * @return null|\Mollie\Api\Resources\PaymentCollection
      */
     public function payments()
     {

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -447,4 +447,19 @@ class Order extends BaseResource
     {
         return $this->client->orderPayments->createFor($this, $data, $filters);
     }
+
+    /**
+     * Retrieve the payments for this order.
+     * Requires the order to be retrieved using the include payments parameter.
+     *
+     * @return \Mollie\Api\Resources\PaymentCollection
+     */
+    public function payments()
+    {
+        return ResourceFactory::createCursorResourceCollection(
+            $this->client,
+            $this->_embedded->payments,
+            Payment::class
+        );
+    }
 }

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -440,7 +440,7 @@ class Order extends BaseResource
      *
      * @param $data
      * @param array $filters
-     * @return \Mollie\Api\Resources\BaseResource|\Mollie\Api\Resources\Order
+     * @return \Mollie\Api\Resources\BaseResource|\Mollie\Api\Resources\Payment
      * @throws \Mollie\Api\Exceptions\ApiException
      */
     public function createPayment($data, $filters = [])

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -450,12 +450,16 @@ class Order extends BaseResource
 
     /**
      * Retrieve the payments for this order.
-     * Requires the order to be retrieved using the include payments parameter.
+     * Requires the order to be retrieved using the embed payments parameter.
      *
      * @return \Mollie\Api\Resources\PaymentCollection
      */
     public function payments()
     {
+        if(! isset($this->_embedded, $this->_embedded->payments) ) {
+            return null;
+        }
+
         return ResourceFactory::createCursorResourceCollection(
             $this->client,
             $this->_embedded->payments,

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -215,6 +215,11 @@ class Payment extends BaseResource
     public $_links;
 
     /**
+     * @var object[]
+     */
+    public $_embedded;
+
+    /**
      * Whether or not this payment can be canceled.
      *
      * @var bool|null

--- a/tests/Mollie/API/Endpoints/OrderEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OrderEndpointTest.php
@@ -230,7 +230,7 @@ class OrderEndpointTest extends BaseEndpointTest
         $this->mockApiCall(
             new Request(
                 "GET",
-                "/v2/orders/ord_kEn1PlbGa?include=payments"
+                "/v2/orders/ord_kEn1PlbGa?embed=payments"
             ),
             new Response(
                 200,
@@ -443,7 +443,7 @@ class OrderEndpointTest extends BaseEndpointTest
             )
         );
 
-        $order = $this->apiClient->orders->get('ord_kEn1PlbGa', ['include' => 'payments']);
+        $order = $this->apiClient->orders->get('ord_kEn1PlbGa', ['embed' => 'payments']);
 
         $this->assertInstanceOf(Order::class, $order);
         $this->assertEquals('ord_kEn1PlbGa', $order->id);
@@ -822,6 +822,8 @@ class OrderEndpointTest extends BaseEndpointTest
         $line2->totalAmount = $this->createAmountObject("329.99", "EUR");
         $line2->createdAt = "2018-08-02T09:29:56+00:00";
         $this->assertEquals($line2, $order->lines[1]);
+
+        $this->assertNull($order->payments());
     }
 
     protected function getOrder($id)

--- a/tests/Mollie/API/Endpoints/OrderEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OrderEndpointTest.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Mollie\Api\Resources\Order;
 use Mollie\Api\Resources\OrderCollection;
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Resources\PaymentCollection;
 use Mollie\Api\Resources\Shipment;
 use Mollie\Api\Types\OrderLineStatus;
 use Mollie\Api\Types\OrderLineType;
@@ -221,6 +223,264 @@ class OrderEndpointTest extends BaseEndpointTest
         $order = $this->apiClient->orders->get('ord_pbjz8x');
 
         $this->assertOrder($order, 'ord_pbjz8x');
+    }
+
+    public function testGetOrderDirectlyIncludingPayments()
+    {
+        $this->mockApiCall(
+            new Request(
+                "GET",
+                "/v2/orders/ord_kEn1PlbGa?include=payments"
+            ),
+            new Response(
+                200,
+                [],
+                '{
+                     "resource": "order",
+                     "id": "ord_kEn1PlbGa",
+                     "profileId": "pfl_URR55HPMGx",
+                     "method": "klarnapaylater",
+                     "amount": {
+                         "value": "1027.99",
+                         "currency": "EUR"
+                     },
+                     "status": "created",
+                     "isCancelable": true,
+                     "metadata": null,
+                     "createdAt": "2018-08-02T09:29:56+00:00",
+                     "expiresAt": "2018-08-30T09:29:56+00:00",
+                     "mode": "live",
+                     "locale": "nl_NL",
+                     "billingAddress": {
+                         "organizationName": "Mollie B.V.",
+                         "streetAndNumber": "Keizersgracht 313",
+                         "postalCode": "1016 EE",
+                         "city": "Amsterdam",
+                         "country": "nl",
+                         "givenName": "Luke",
+                         "familyName": "Skywalker",
+                         "email": "luke@skywalker.com"
+                     },
+                     "orderNumber": "18475",
+                     "shippingAddress": {
+                         "organizationName": "Mollie B.V.",
+                         "streetAndNumber": "Keizersgracht 313",
+                         "postalCode": "1016 EE",
+                         "city": "Amsterdam",
+                         "country": "nl",
+                         "givenName": "Luke",
+                         "familyName": "Skywalker",
+                         "email": "luke@skywalker.com"
+                     },
+                     "redirectUrl": "https://example.org/redirect",
+                     "lines": [
+                         {
+                             "resource": "orderline",
+                             "id": "odl_dgtxyl",
+                             "orderId": "ord_pbjz8x",
+                             "name": "LEGO 42083 Bugatti Chiron",
+                             "sku": "5702016116977",
+                             "type": "physical",
+                             "status": "created",
+                             "metadata": null,
+                             "isCancelable": false,
+                             "quantity": 2,
+                             "quantityShipped": 0,
+                             "amountShipped": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "quantityRefunded": 0,
+                             "amountRefunded": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "quantityCanceled": 0,
+                             "amountCanceled": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "shippableQuantity": 0,
+                             "refundableQuantity": 0,
+                             "cancelableQuantity": 0,
+                             "unitPrice": {
+                                 "value": "399.00",
+                                 "currency": "EUR"
+                             },
+                             "vatRate": "21.00",
+                             "vatAmount": {
+                                 "value": "121.14",
+                                 "currency": "EUR"
+                             },
+                             "discountAmount": {
+                                 "value": "100.00",
+                                 "currency": "EUR"
+                             },
+                             "totalAmount": {
+                                 "value": "698.00",
+                                 "currency": "EUR"
+                             },
+                             "createdAt": "2018-08-02T09:29:56+00:00",
+                             "_links": {
+                                 "productUrl": {
+                                     "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                                     "type": "text/html"
+                                 },
+                                 "imageUrl": {
+                                     "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                                     "type": "text/html"
+                                 }
+                             }
+                         },
+                         {
+                             "resource": "orderline",
+                             "id": "odl_jp31jz",
+                             "orderId": "ord_pbjz8x",
+                             "name": "LEGO 42056 Porsche 911 GT3 RS",
+                             "sku": "5702015594028",
+                             "type": "physical",
+                             "status": "created",
+                             "metadata": null,
+                             "isCancelable": false,
+                             "quantity": 1,
+                             "quantityShipped": 0,
+                             "amountShipped": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "quantityRefunded": 0,
+                             "amountRefunded": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "quantityCanceled": 0,
+                             "amountCanceled": {
+                                 "value": "0.00",
+                                 "currency": "EUR"
+                             },
+                             "shippableQuantity": 0,
+                             "refundableQuantity": 0,
+                             "cancelableQuantity": 0,
+                             "unitPrice": {
+                                 "value": "329.99",
+                                 "currency": "EUR"
+                             },
+                             "vatRate": "21.00",
+                             "vatAmount": {
+                                 "value": "57.27",
+                                 "currency": "EUR"
+                             },
+                             "totalAmount": {
+                                 "value": "329.99",
+                                 "currency": "EUR"
+                             },
+                             "createdAt": "2018-08-02T09:29:56+00:00",
+                             "_links": {
+                                 "productUrl": {
+                                     "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                                     "type": "text/html"
+                                 },
+                                 "imageUrl": {
+                                     "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                                     "type": "text/html"
+                                 }
+                             }
+                         }
+                     ],
+                     "_embedded": {
+                         "payments": [
+                             {
+                                 "resource": "payment",
+                                 "id": "tr_ncaPcAhuUV",
+                                 "mode": "live",
+                                 "createdAt": "2018-09-07T12:00:05+00:00",
+                                 "amount": {
+                                     "value": "1027.99",
+                                     "currency": "EUR"
+                                 },
+                                 "description": "Order #1337 (Lego cars)",
+                                 "method": null,
+                                 "metadata": null,
+                                 "status": "open",
+                                 "isCancelable": false,
+                                 "locale": "nl_NL",
+                                 "profileId": "pfl_URR55HPMGx",
+                                 "orderId": "ord_kEn1PlbGa",
+                                 "sequenceType": "oneoff",
+                                 "redirectUrl": "https://example.org/redirect",
+                                 "_links": {
+                                     "self": {
+                                         "href": "https://api.mollie.com/v2/payments/tr_ncaPcAhuUV",
+                                         "type": "application/hal+json"
+                                     },
+                                     "checkout": {
+                                         "href": "https://www.mollie.com/payscreen/select-method/ncaPcAhuUV",
+                                         "type": "text/html"
+                                     },
+                                     "order": {
+                                         "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+                                         "type": "application/hal+json"
+                                     }
+                                 }
+                             }
+                         ]
+                     },
+                     "_links": {
+                         "self": {
+                             "href": "https://api.mollie.com/v2/orders/ord_pbjz8x",
+                             "type": "application/hal+json"
+                         },
+                         "checkout": {
+                             "href": "https://www.mollie.com/payscreen/order/checkout/pbjz8x",
+                             "type": "text/html"
+                         },
+                         "documentation": {
+                             "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+                             "type": "text/html"
+                         }
+                     }
+                 }'
+            )
+        );
+
+        $order = $this->apiClient->orders->get('ord_kEn1PlbGa', ['include' => 'payments']);
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals('ord_kEn1PlbGa', $order->id);
+
+        $payments = $order->payments();
+        $this->assertInstanceOf(PaymentCollection::class, $payments);
+
+        $payment = $payments[0];
+        $this->assertInstanceOf(Payment::class, $payment);
+        $this->assertEquals('tr_ncaPcAhuUV', $payment->id);
+        $this->assertEquals('2018-09-07T12:00:05+00:00', $payment->createdAt);
+        $this->assertAmountObject('1027.99', 'EUR', $payment->amount);
+        $this->assertEquals('Order #1337 (Lego cars)', $payment->description);
+        $this->assertNull($payment->method);
+        $this->assertNull($payment->metadata);
+        $this->assertEquals('open', $payment->status);
+        $this->assertFalse($payment->isCancelable);
+        $this->assertEquals('nl_NL', $payment->locale);
+        $this->assertEquals('pfl_URR55HPMGx', $payment->profileId);
+        $this->assertEquals('ord_kEn1PlbGa', $payment->orderId);
+        $this->assertEquals('oneoff', $payment->sequenceType);
+        $this->assertEquals('https://example.org/redirect', $payment->redirectUrl);
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/payments/tr_ncaPcAhuUV',
+            'application/hal+json',
+            $payment->_links->self
+        );
+        $this->assertLinkObject(
+            'https://www.mollie.com/payscreen/select-method/ncaPcAhuUV',
+            'text/html',
+            $payment->_links->checkout
+        );
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/orders/ord_kEn1PlbGa',
+            'application/hal+json',
+            $payment->_links->order
+        );
     }
 
     public function testGetOrderOnShipmentResource()

--- a/tests/Mollie/API/Resources/OrderTest.php
+++ b/tests/Mollie/API/Resources/OrderTest.php
@@ -272,6 +272,19 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($order->getCheckoutUrl());
     }
 
+    public function testPaymentsHelperReturnsIfNoEmbedAvailable()
+    {
+        $order = new Order($this->createMock(MollieApiClient::class));
+        $this->assertNull($order->payments());
+    }
+
+    public function testPaymentsHelperReturnsIfNoPaymentsEmbedded()
+    {
+        $order = new Order($this->createMock(MollieApiClient::class));
+        $order->_embedded = [];
+        $this->assertNull($order->payments());
+    }
+
     protected function getOrderLinksDummy($overrides = [])
     {
         return (object) array_merge(

--- a/tests/Mollie/API/Resources/OrderTest.php
+++ b/tests/Mollie/API/Resources/OrderTest.php
@@ -110,8 +110,76 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-
     public function testCanGetLinesAsResourcesOnOrderResource()
+    {
+        $order = new Order($this->createMock(MollieApiClient::class));
+        $orderLine = new stdClass;
+        $lineArray = [
+            'resource' => 'orderline',
+            'id' => 'odl_dgtxyl',
+            'orderId' => 'ord_pbjz8x',
+            'type' => 'physical',
+            'name' => 'LEGO 42083 Bugatti Chiron',
+            'productUrl' => 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
+            'imageUrl' => 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
+            'sku' => '5702016116977',
+            'type' => 'physical',
+            'status' => 'created',
+            'quantity' => 2,
+            'unitPrice' => (object) [
+                'value' => '399.00',
+                'currency' => 'EUR',
+            ],
+            'vatRate' => '21.00',
+            'vatAmount' => (object) [
+                'value' => '121.14',
+                'currency' => 'EUR',
+            ],
+            'discountAmount' => (object) [
+                'value' => '100.00',
+                'currency' => 'EUR',
+            ],
+            'totalAmount' => (object) [
+                'value' => '698.00',
+                'currency' => 'EUR',
+            ],
+            'createdAt' => '2018-08-02T09:29:56+00:00',
+        ];
+
+        foreach ($lineArray as $key => $value) {
+            $orderLine->{$key} = $value;
+        }
+
+        $order->lines = [$orderLine];
+
+        $lines = $order->lines();
+
+        $this->assertInstanceOf(OrderLineCollection::class, $lines);
+        $this->assertCount(1, $lines);
+
+        $line = $lines[0];
+
+        $this->assertInstanceOf(OrderLine::class, $line);
+
+        $this->assertEquals("orderline", $line->resource);
+        $this->assertEquals("odl_dgtxyl", $line->id);
+        $this->assertEquals('ord_pbjz8x', $line->orderId);
+        $this->assertEquals("LEGO 42083 Bugatti Chiron", $line->name);
+        $this->assertEquals("https://shop.lego.com/nl-NL/Bugatti-Chiron-42083", $line->productUrl);
+        $this->assertEquals('https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$', $line->imageUrl);
+        $this->assertEquals("5702016116977", $line->sku);
+        $this->assertEquals(OrderLineType::TYPE_PHYSICAL, $line->type);
+        $this->assertEquals(OrderLineStatus::STATUS_CREATED, $line->status);
+        $this->assertEquals(2, $line->quantity);
+        $this->assertAmountObject("399.00", "EUR", $line->unitPrice);
+        $this->assertEquals("21.00", $line->vatRate);
+        $this->assertAmountObject("121.14", "EUR", $line->vatAmount);
+        $this->assertAmountObject("100.00", "EUR", $line->discountAmount);
+        $this->assertAmountObject("698.00", "EUR", $line->totalAmount);
+        $this->assertEquals("2018-08-02T09:29:56+00:00", $line->createdAt);
+    }
+
+    public function testCanGetPaymentsAsResourcesOnOrderResource()
     {
         $order = new Order($this->createMock(MollieApiClient::class));
         $orderLine = new stdClass;


### PR DESCRIPTION
Retrieves the nested payments as a PaymentsCollection.

Requires the Order to be retrieved using the `include=payments` flag.