### PR TITLE
Bugfix for fetching settlement payments

### DIFF
--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -132,7 +132,7 @@ class Settlement extends BaseResource
 
         return ResourceFactory::createCursorResourceCollection(
             $this->client,
-            $result->_embedded->methods,
+            $result->_embedded->payments,
             Payment::class,
             $result->_links
         );


### PR DESCRIPTION
Calls to $settlement->payments() will fail with an undefined property exception. 

Seems to be a typo introduced in [this commit](https://github.com/mollie/mollie-api-php/commit/3ac130920d48fee0b6a134f40dd96957d13b33eb#diff-95fba3d27615695bf5afdbd82981e912L212).