### PR TITLE
Travis: allow PHP nightly to fail and switch to xenial images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,38 +2,37 @@ language: php
 
 dist: trusty
 
-php:
-- 5.6
-- 7.0
-- 7.1
-- 7.2
-- 7.3
-
 matrix:
   fast_finish: true
   allow_failures:
-  - php: nightly
+    - php: nightly
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
 
 sudo: false
 
 cache:
   directories:
-  - "$HOME/.composer/cache"
+    - "$HOME/.composer/cache"
 
 env:
-- COMPOSER_NO_INTERACTION=1
+  - COMPOSER_NO_INTERACTION=1
 
 install:
-- travis_retry composer install --no-scripts --no-suggest
+  - travis_retry composer install --no-scripts --no-suggest
 
 script:
-- composer validate --strict
-- find src examples tests -name '*.php' | xargs -n 1 -P4 php -l
-- vendor/bin/phpunit
+  - composer validate --strict
+  - find src examples tests -name '*.php' | xargs -n 1 -P4 php -l
+  - vendor/bin/phpunit
 
 before_deploy:
-- sed -i "/const CLIENT_VERSION/c\\    const CLIENT_VERSION = '${TRAVIS_TAG:1}';" src/MollieApiClient.php
-- make mollie-api-php.zip
+  - sed -i "/const CLIENT_VERSION/c\\    const CLIENT_VERSION = '${TRAVIS_TAG:1}';" src/MollieApiClient.php
+  - make mollie-api-php.zip
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ dist: trusty
 matrix:
   fast_finish: true
   allow_failures:
-    - php: nightly
+  - php: nightly
   include:
     - php: 5.6
     - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: nightly
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,15 @@ matrix:
   include:
     - php: 5.6
     - php: 7.0
+      dist: xenial
     - php: 7.1
+      dist: xenial
     - php: 7.2
+      dist: xenial
     - php: 7.3
+      dist: xenial
     - php: nightly
+      dist: xenial
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 matrix:
   fast_finish: true
@@ -9,15 +9,10 @@ matrix:
   include:
     - php: 5.6
     - php: 7.0
-      dist: xenial
     - php: 7.1
-      dist: xenial
     - php: 7.2
-      dist: xenial
     - php: 7.3
-      dist: xenial
     - php: nightly
-      dist: xenial
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 - 7.1
 - 7.2
 - 7.3
-- nightly
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Removing PHP nightly from the original array, but keeping it under `allow_failures` will allow it to fail.