### PR TITLE
Travis: allow PHP nightly to fail and partial switch to xenial images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
 language: php
-dist: trusty
-
-php:
-- 5.4
-- 5.5
-- 5.6
-- 7.0
-- 7.1
-- 7.2
-- nightly
+dist: xenial
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
   include:
     - php: 5.3
       dist: precise
       sudo: true
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: nightly
 
 sudo: false
 
@@ -23,9 +26,9 @@ cache:
     - $HOME/.composer/cache
 
 install:
-- travis_retry composer install --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
-- composer validate --strict
-- find src examples tests -name '*.php' | xargs -n 1 -P4 php -l
-- vendor/bin/phpunit
+  - composer validate --strict
+  - find src examples tests -name '*.php' | xargs -n 1 -P4 php -l
+  - vendor/bin/phpunit


### PR DESCRIPTION
Same as https://github.com/mollie/mollie-api-php/pull/361, but for the `v1-develop` branch.