### PR TITLE
Improved first payment method mapper

### DIFF
--- a/src/Types/FirstPaymentMethod.php
+++ b/src/Types/FirstPaymentMethod.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mollie\Api\Types;
+
+class FirstPaymentMethod
+{
+    const CREDITCARD = 'creditcard';
+    const BANCONTACT = 'bancontact';
+    const BELFIUS = 'belfius';
+    const EPS = 'eps';
+    const GIROPAY = 'giropay';
+    const IDEAL = 'ideal';
+    const INGHOMEPAY = 'inghomepay';
+    const KBC = 'kbc';
+    const SOFORT = 'sofort';
+
+    /**
+     * Retrieve all methods that can be used for a first payment.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        return [
+            static::CREDITCARD,
+            static::BANCONTACT,
+            static::BELFIUS,
+            static::EPS,
+            static::GIROPAY,
+            static::IDEAL,
+            static::INGHOMEPAY,
+            static::KBC,
+            static::SOFORT,
+        ];
+    }
+
+    /**
+     * Whether the method can be used as a first payment method.
+     *
+     * @param $method
+     * @return bool
+     */
+    public static function exists($method)
+    {
+        return in_array($method, static::all());
+    }
+}

--- a/src/Types/MandateMethod.php
+++ b/src/Types/MandateMethod.php
@@ -9,6 +9,10 @@ class MandateMethod
 
     public static function getForFirstPaymentMethod($firstPaymentMethod)
     {
+        if(! FirstPaymentMethod::exists($firstPaymentMethod)) {
+            return null;
+        }
+
         if($firstPaymentMethod === static::CREDITCARD) {
             return static::CREDITCARD;
         }

--- a/tests/Mollie/API/Types/FirstPaymentMethodTest.php
+++ b/tests/Mollie/API/Types/FirstPaymentMethodTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Mollie\API\Types;
+
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Types\FirstPaymentMethod;
+use Mollie\Api\Types\PaymentMethod;
+use PHPUnit\Framework\TestCase;
+
+class FirstPaymentMethodTest extends TestCase
+{
+    public function testGetAll()
+    {
+        $this->assertEquals([
+            'creditcard',
+            'bancontact',
+            'belfius',
+            'eps',
+            'giropay',
+            'ideal',
+            'inghomepay',
+            'kbc',
+            'sofort',
+        ], FirstPaymentMethod::all());
+    }
+
+    public function testExists()
+    {
+        $this->assertTrue(FirstPaymentMethod::exists(PaymentMethod::CREDITCARD));
+        $this->assertFalse(FirstPaymentMethod::exists(PaymentMethod::KLARNA_PAY_LATER));
+    }
+}

--- a/tests/Mollie/API/Types/MandateMethodTest.php
+++ b/tests/Mollie/API/Types/MandateMethodTest.php
@@ -31,6 +31,7 @@ class MandateMethodTest extends TestCase
             [PaymentMethod::INGHOMEPAY, MandateMethod::DIRECTDEBIT],
             [PaymentMethod::KBC, MandateMethod::DIRECTDEBIT],
             [PaymentMethod::SOFORT, MandateMethod::DIRECTDEBIT],
+            [PaymentMethod::KLARNA_PAY_LATER, null],
         ];
     }
 }


### PR DESCRIPTION
Should return `null` for non-first-payment methods.

This requires introducing the `FirstPaymentMethod` type, along with some methods (`all`, `exists`).