### PR TITLE
Methods: all, allAvailable, allActive

### DIFF
--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -5,6 +5,7 @@ namespace Mollie\Api\Endpoints;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Method;
 use Mollie\Api\Resources\MethodCollection;
+use Mollie\Api\Resources\ResourceFactory;
 
 class MethodEndpoint extends EndpointAbstract
 {
@@ -33,7 +34,8 @@ class MethodEndpoint extends EndpointAbstract
     }
 
     /**
-     * Retrieve all active methods. The results are not paginated. In test mode, this includes pending methods.
+     * Retrieve all active methods for the organization. In test mode, this includes pending methods.
+     * The results are not paginated.
      *
      * @param array $parameters
      *
@@ -43,6 +45,32 @@ class MethodEndpoint extends EndpointAbstract
     public function allActive(array $parameters = [])
     {
         return parent::rest_list(null, null, $parameters);
+    }
+
+    /**
+     * Retrieve all available methods for the organization, including activated and not yet activated methods.
+     * The results are not paginated.
+     *
+     * @param array $parameters
+     *
+     * @return \Mollie\Api\Resources\BaseCollection|\Mollie\Api\Resources\MethodCollection
+     * @throws ApiException
+     */
+    public function allAvailable(array $parameters = [])
+    {
+        $body = null;
+        if (count($parameters) > 0) {
+            $body = json_encode($parameters);
+        }
+
+        $result = $this->client->performHttpCall('GET', 'methods/all', $body);
+
+        return ResourceFactory::createBaseResourceCollection(
+            $this->client,
+            $result->_embedded->methods,
+            Method::class,
+            $result->_links
+        );
     }
 
     /**

--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -20,7 +20,7 @@ class MethodEndpoint extends EndpointAbstract
     }
 
     /**
-     * Retrieve all active methods. The results are not paginated. In test mode, this includes pending methods.
+     * Retrieve all active methods. In test mode, this includes pending methods. The results are not paginated.
      *
      * @deprecated Use allActive() instead
      * @param array $parameters

--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -19,6 +19,33 @@ class MethodEndpoint extends EndpointAbstract
     }
 
     /**
+     * Retrieve all active methods. The results are not paginated. In test mode, this includes pending methods.
+     *
+     * @deprecated Use allActive() instead
+     * @param array $parameters
+     *
+     * @return \Mollie\Api\Resources\BaseCollection|\Mollie\Api\Resources\MethodCollection
+     * @throws ApiException
+     */
+    public function all(array $parameters = [])
+    {
+        return $this->allActive($parameters);
+    }
+
+    /**
+     * Retrieve all active methods. The results are not paginated. In test mode, this includes pending methods.
+     *
+     * @param array $parameters
+     *
+     * @return \Mollie\Api\Resources\BaseCollection|\Mollie\Api\Resources\MethodCollection
+     * @throws ApiException
+     */
+    public function allActive(array $parameters = [])
+    {
+        return parent::rest_list(null, null, $parameters);
+    }
+
+    /**
      * Get the collection object that is used by this API endpoint. Every API endpoint uses one type of collection object.
      *
      * @param int $count
@@ -48,18 +75,5 @@ class MethodEndpoint extends EndpointAbstract
         }
 
         return parent::rest_read($methodId, $parameters);
-    }
-
-    /**
-     * Retrieve all methods.
-     *
-     * @param array $parameters
-     *
-     * @return MethodCollection
-     * @throws ApiException
-     */
-    public function all(array $parameters = [])
-    {
-        return parent::rest_list(null, null, $parameters);
     }
 }

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -374,7 +374,7 @@ class MethodEndpointTest extends BaseEndpointTest
             )
         );
 
-        $methods = $this->apiClient->methods->all();
+        $methods = $this->apiClient->methods->allActive();
 
         $this->assertInstanceOf(MethodCollection::class, $methods);
         $this->assertEquals(4, $methods->count);

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -287,7 +287,7 @@ class MethodEndpointTest extends BaseEndpointTest
         $this->assertEquals($documentationLink, $method->_links->documentation);
     }
 
-    public function testListMethods()
+    public function testListAllActiveMethods()
     {
         $this->mockApiCall(
             new Request('GET', '/v2/methods'),
@@ -375,6 +375,126 @@ class MethodEndpointTest extends BaseEndpointTest
         );
 
         $methods = $this->apiClient->methods->allActive();
+
+        $this->assertInstanceOf(MethodCollection::class, $methods);
+        $this->assertEquals(4, $methods->count);
+        $this->assertCount(4, $methods);
+
+        $documentationLink = (object)[
+            'href' => 'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+            'type' => 'text/html'
+        ];
+        $this->assertEquals($documentationLink, $methods->_links->documentation);
+
+        $selfLink = (object)[
+            'href' => 'http://api.mollie.com/v2/methods',
+            'type' => 'application/hal+json'
+        ];
+        $this->assertEquals($selfLink, $methods->_links->self);
+
+        $creditcardMethod = $methods[1];
+
+        $this->assertInstanceOf(Method::class, $creditcardMethod);
+        $this->assertEquals('creditcard', $creditcardMethod->id);
+        $this->assertEquals('Credit card', $creditcardMethod->description);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
+
+        $selfLink = (object)[
+            'href' => 'https://api.mollie.com/v2/methods/creditcard',
+            'type' => 'application/hal+json'
+        ];
+        $this->assertEquals($selfLink, $creditcardMethod->_links->self);
+    }
+
+    public function testListAllAvailableMethods()
+    {
+        $this->mockApiCall(
+            new Request('GET', '/v2/methods/all'),
+            new Response(
+                200,
+                [],
+                '{
+                    "_embedded": {
+                        "methods": [
+                            {
+                                "resource": "method",
+                                "id": "ideal",
+                                "description": "iDEAL",
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/ideal",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "creditcard",
+                                "description": "Credit card",
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/creditcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "mistercash",
+                                "description": "Bancontact",
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/mistercash",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "giftcard",
+                                "description": "Gift cards",
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/giftcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "count": 4,
+                    "_links": {
+                        "documentation": {
+                            "href": "https://docs.mollie.com/reference/v2/methods-api/list-methods",
+                            "type": "text/html"
+                        },
+                        "self": {
+                            "href": "http://api.mollie.com/v2/methods",
+                            "type": "application/hal+json"
+                        }
+                    }
+                }'
+            )
+        );
+
+        $methods = $this->apiClient->methods->allAvailable();
 
         $this->assertInstanceOf(MethodCollection::class, $methods);
         $this->assertEquals(4, $methods->count);


### PR DESCRIPTION
See Issue #364

* [x] Mark `$mollie->methods->all()` as `deprecated`
* [x] For `LIST /v2/methods` provide `$mollie->methods->allActive()`
* [x] For `ALL /v2/methods/all` provide `$mollie->methods->allAvailable()`