### PR TITLE
Filter mandates by status, housekeeping

### DIFF
--- a/src/Endpoints/EndpointAbstract.php
+++ b/src/Endpoints/EndpointAbstract.php
@@ -141,7 +141,7 @@ abstract class EndpointAbstract
      * @return BaseCollection
      * @throws ApiException
      */
-    protected function rest_list($from = null, $limit = null, array $filters)
+    protected function rest_list($from = null, $limit = null, array $filters = [])
     {
         $filters = array_merge(["from" => $from, "limit" => $limit], $filters);
 

--- a/src/Endpoints/MandateEndpoint.php
+++ b/src/Endpoints/MandateEndpoint.php
@@ -110,7 +110,7 @@ class MandateEndpoint extends EndpointAbstract
      * @param null $limit
      * @param array $parameters
      *
-     * @return \Mollie\Api\Resources\BaseCollection
+     * @return \Mollie\Api\Resources\BaseCollection|\Mollie\Api\Resources\MandateCollection
      * @throws \Mollie\Api\Exceptions\ApiException
      */
     public function listForId($customerId, $from = null, $limit = null, array $parameters = [])

--- a/src/Resources/MandateCollection.php
+++ b/src/Resources/MandateCollection.php
@@ -19,4 +19,21 @@ class MandateCollection extends CursorCollection
     {
         return new Mandate($this->client);
     }
+
+    /**
+     * @param string $status
+     * @return array|\Mollie\Api\Resources\MandateCollection
+     */
+    public function whereStatus($status)
+    {
+        $collection = new self($this->client, $this->count, $this->_links);
+
+        foreach ($this as $item) {
+            if($item->status === $status) {
+                $collection[] = $item;
+            }
+        }
+
+        return $collection;
+    }
 }

--- a/tests/Mollie/API/Resources/MandateCollectionTest.php
+++ b/tests/Mollie/API/Resources/MandateCollectionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Mollie\API\Resources;
+
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Mandate;
+use Mollie\Api\Resources\MandateCollection;
+use Mollie\Api\Types\MandateStatus;
+use PHPUnit\Framework\TestCase;
+
+class MandateCollectionTest extends TestCase
+{
+    /**
+     * @var \Mollie\Api\MollieApiClient
+     */
+    protected $client;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->client = $this->createMock(MollieApiClient::class);
+    }
+
+    public function testWhereStatus()
+    {
+        $collection = new MandateCollection($this->client, 3, null);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_VALID);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_VALID);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_VALID);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_INVALID);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_INVALID);
+        $collection[] = $this->getMandateWithStatus(MandateStatus::STATUS_PENDING);
+
+        $valid = $collection->whereStatus(MandateStatus::STATUS_VALID);
+        $invalid = $collection->whereStatus(MandateStatus::STATUS_INVALID);
+        $pending = $collection->whereStatus(MandateStatus::STATUS_PENDING);
+
+        $this->assertInstanceOf(MandateCollection::class, $collection);
+        $this->assertInstanceOf(MandateCollection::class, $valid);
+        $this->assertInstanceOf(MandateCollection::class, $invalid);
+        $this->assertInstanceOf(MandateCollection::class, $pending);
+
+        $this->assertCount(6, $collection);
+        $this->assertCount(3, $valid);
+        $this->assertCount(2, $invalid);
+        $this->assertCount(1, $pending);
+    }
+
+    /**
+     * @param string $status
+     * @return \Mollie\Api\Resources\Mandate
+     */
+    protected function getMandateWithStatus($status)
+    {
+        $mandate = new Mandate($this->client);
+        $mandate->status = $status;
+
+        return $mandate;
+    }
+}


### PR DESCRIPTION
Adds a `whereStatus($status)` filter method to `MandateCollection`.

If desired, I can also add shortcuts for `whereStatusValid()` / `whereStatusInvalid()` / `whereStatusPending()`.

Also, `whereStatus($status)` could be an interesting candidate for a trait, so it also can be used with other resources (i.e. `Payment`).

@Smitsel What do you think?

PS. This would be the first trait in the package, not sure if there's any Mollie coding style guide against that. The package is PHP 5.6 and up, so no problem there.