### PR TITLE
Add phpstan to CI

### DIFF
--- a/.phpstan.ignoreErrors.neon
+++ b/.phpstan.ignoreErrors.neon
@@ -1,0 +1,14 @@
+parameters:
+    ignoreErrors:
+        -
+            message: '/Undefined variable: \$mollie/'
+            paths:
+                - %currentWorkingDirectory%/examples
+        -
+            message: '/Function database_(write|read) not found/'
+            paths:
+                - %currentWorkingDirectory%/examples
+        -
+            message: '/Function printOrders not found/'
+            paths:
+                - %currentWorkingDirectory%/examples

--- a/.phpstan.ignoreErrors.neon
+++ b/.phpstan.ignoreErrors.neon
@@ -12,3 +12,8 @@ parameters:
             message: '/Function printOrders not found/'
             paths:
                 - %currentWorkingDirectory%/examples
+
+        -
+            message: "#^Call to an undefined method Mollie\\\\Api\\\\Endpoints\\\\EndpointAbstract\\:\\:getResourceCollectionObject\\(\\)\\.$#"
+            count: 1
+            path: src/Endpoints/EndpointAbstract.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-      env: PHPSTAN=1
+      env:
+        - COMPOSER_NO_INTERACTION=1
+        - PHPSTAN=0.11.19
     - php: nightly
 
 sudo: false
@@ -28,7 +30,7 @@ install:
   - travis_retry composer install --no-scripts --no-suggest
 
 before_script:
-  - test -z "${PHPSTAN}" || vendor/bin/phpstan analyse -c phpstan.neon --no-progress
+  - test -z "${PHPSTAN}" || (composer require phpstan/phpstan="${PHPSTAN}" && vendor/bin/phpstan analyse -c phpstan.neon --no-progress)
 
 script:
   - composer validate --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+      env: PHPSTAN=1
     - php: nightly
 
 sudo: false
@@ -25,6 +26,9 @@ env:
 
 install:
   - travis_retry composer install --no-scripts --no-suggest
+
+before_script:
+  - test -z "${PHPSTAN}" || vendor/bin/phpstan analyse -c phpstan.neon --no-progress
 
 script:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
   },
   "require-dev": {
     "eloquent/liberator": "^2.0",
-    "phpstan/phpstan": "^0.11.19",
     "phpunit/phpunit": "^5.7 || ^6.5 || ^7.1"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
   },
   "require-dev": {
     "eloquent/liberator": "^2.0",
+    "phpstan/phpstan": "^0.11.19",
     "phpunit/phpunit": "^5.7 || ^6.5 || ^7.1"
   },
   "suggest": {
@@ -71,7 +72,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\": "tests"
+      "Tests\\": "tests/",
+      "Tests\\Mollie\\Api\\": "tests/Mollie/API/"
     }
   },
   "scripts": {

--- a/examples/shipments/create-shipment-partial.php
+++ b/examples/shipments/create-shipment-partial.php
@@ -15,7 +15,7 @@ try {
      * See: https://docs.mollie.com/reference/v2/shipments-api/create-shipment
      */
 
-    $order = $this->getOrder('ord_8wmqcHMN4U');
+    $order = $mollie->orders->get('ord_8wmqcHMN4U');
     $lineId1 = $order->lines()[0]->id;
     $lineId2 = $order->lines()[1]->id;
     $shipment = $order->createShipment(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+parameters:
+    level: 1
+    paths:
+        - %currentWorkingDirectory%/src
+        - %currentWorkingDirectory%/tests
+        - %currentWorkingDirectory%/examples
+    excludes_analyse:
+        - %currentWorkingDirectory%/vendor
+includes:
+    - .phpstan.ignoreErrors.neon

--- a/src/Endpoints/OnboardingEndpoint.php
+++ b/src/Endpoints/OnboardingEndpoint.php
@@ -11,6 +11,10 @@ class OnboardingEndpoint extends EndpointAbstract
 {
     protected $resourcePath = "onboarding/me";
 
+    protected function getResourceCollectionObject($count, $links)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
     /**
      * Get the object that is used by this API endpoint. Every API endpoint uses one type of object.
      *

--- a/src/Endpoints/OrderLineEndpoint.php
+++ b/src/Endpoints/OrderLineEndpoint.php
@@ -73,7 +73,7 @@ class OrderLineEndpoint extends CollectionEndpointAbstract
      */
     public function cancelForId($orderId, array $data)
     {
-        if(! isset($data, $data['lines']) || ! is_array($data['lines'])) {
+        if(! isset($data['lines']) || ! is_array($data['lines'])) {
             throw new ApiException("A lines array is required.");
         }
         $this->parentId = $orderId;

--- a/src/Endpoints/PermissionEndpoint.php
+++ b/src/Endpoints/PermissionEndpoint.php
@@ -32,7 +32,7 @@ class PermissionEndpoint extends CollectionEndpointAbstract
      */
     protected function getResourceCollectionObject($count, $_links)
     {
-        return new PermissionCollection($this->client, $count, $_links);
+        return new PermissionCollection($count, $_links);
     }
 
     /**

--- a/src/Endpoints/ShipmentEndpoint.php
+++ b/src/Endpoints/ShipmentEndpoint.php
@@ -36,7 +36,7 @@ class ShipmentEndpoint extends CollectionEndpointAbstract
      */
     protected function getResourceCollectionObject($count, $_links)
     {
-        return new ShipmentCollection($this->client, $count, $_links);
+        return new ShipmentCollection($count, $_links);
     }
 
     /**

--- a/src/Resources/BaseCollection.php
+++ b/src/Resources/BaseCollection.php
@@ -24,6 +24,7 @@ abstract class BaseCollection extends \ArrayObject
     {
         $this->count = $count;
         $this->_links = $_links;
+        parent::__construct();
     }
 
     /**

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -159,6 +159,11 @@ class Order extends BaseResource
     public $_links;
 
     /**
+     * @var \stdClass
+     */
+    public $_embedded;
+
+    /**
      * Is this order created?
      *
      * @return bool

--- a/tests/Mollie/API/CompatibilityCheckerTest.php
+++ b/tests/Mollie/API/CompatibilityCheckerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tests\Mollie\Api;
 
-use Mollie\Api\CompatibilityChecker;
+use \Mollie\Api\CompatibilityChecker;
 
 class CompatibilityCheckerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Mollie/API/Endpoints/OnboardingEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OnboardingEndpointTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Mollie\API\Endpoints;
+namespace Tests\Mollie\Api\Endpoints;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;

--- a/tests/Mollie/API/Endpoints/PaymentRefundEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/PaymentRefundEndpointTest.php
@@ -127,7 +127,7 @@ class PaymentRefundEndpointTest extends BaseEndpointTest
             )
         );
 
-        $refund = $this->getPayment("tr_44aKxzEbr8")->getRefund("re_PsAvxvLsnm");
+        $refund = $this->getPayment()->getRefund("re_PsAvxvLsnm");
 
         $this->assertInstanceOf(Refund::class, $refund);
         $this->assertEquals("re_PsAvxvLsnm", $refund->id);

--- a/tests/Mollie/API/Endpoints/WalletEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/WalletEndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Mollie\API\Endpoints;
+namespace Tests\Mollie\Api\Endpoints;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;

--- a/tests/Mollie/API/Resources/OrderLineCollectionTest.php
+++ b/tests/Mollie/API/Resources/OrderLineCollectionTest.php
@@ -11,7 +11,7 @@ class OrderLineCollectionTest extends \PHPUnit\Framework\TestCase
     public function testCanGetOrderLine()
     {
         $mockApi = $this->createMock(MollieApiClient::class);
-        $lines = new OrderLineCollection($mockApi, 3, []);
+        $lines = new OrderLineCollection(3, []);
 
         $line1 = new OrderLine($mockApi);
         $line1->id = 'odl_aaaaaaaaaaa1';

--- a/tests/Mollie/API/Resources/OrderTest.php
+++ b/tests/Mollie/API/Resources/OrderTest.php
@@ -123,7 +123,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
             'productUrl' => 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
             'imageUrl' => 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
             'sku' => '5702016116977',
-            'type' => 'physical',
             'status' => 'created',
             'quantity' => 2,
             'unitPrice' => (object) [
@@ -192,7 +191,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
             'productUrl' => 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
             'imageUrl' => 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
             'sku' => '5702016116977',
-            'type' => 'physical',
             'status' => 'created',
             'quantity' => 2,
             'unitPrice' => (object) [

--- a/tests/Mollie/TestHelpers/AmountObjectTestHelpers.php
+++ b/tests/Mollie/TestHelpers/AmountObjectTestHelpers.php
@@ -6,7 +6,7 @@ trait AmountObjectTestHelpers
 {
     protected function assertAmountObject($value, $currency, $amountObject)
     {
-        return $this->assertEquals(
+        $this->assertEquals(
             $this->createAmountObject($value, $currency),
             $amountObject
         );

--- a/tests/Mollie/TestHelpers/LinkObjectTestHelpers.php
+++ b/tests/Mollie/TestHelpers/LinkObjectTestHelpers.php
@@ -6,7 +6,7 @@ trait LinkObjectTestHelpers
 {
     protected function assertLinkObject($href, $type, $linkObject)
     {
-        return $this->assertEquals(
+        $this->assertEquals(
             $this->createLinkObject($href, $type),
             $linkObject
         );


### PR DESCRIPTION
As suggested by @willemstuursma, here is a patch that adds phpstan to the travis definition. To pass phpstan level 1, I also had to make a couple of changes, mainly in type definitions and erroneous function calls.