### PR TITLE
first implementation of getCosts()

### DIFF
--- a/src/Resources/MethodPriceCollection.php
+++ b/src/Resources/MethodPriceCollection.php
@@ -11,4 +11,21 @@ class MethodPriceCollection extends BaseCollection
     {
         return null;
     }
+
+    /**
+     * Get a specific MethodPrice.
+     * Returns null if the MethodPrice cannot be found.
+     *
+     * @param  string $description
+     * @return MethodPrice|null
+     */
+    public function get($description)
+    {
+        foreach ($this as $methodPrice) {
+            if ($methodPrice->description === $description) {
+                return $methodPrice;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Calculate costs based on MethodPrice
rounding is done on 3 decimals
Currently, only the following methods are supported:
- creditcard/american-express
- creditcard/intra-eu
- creditcard/business
- bancontact
- inghomepay
- kbc
- belfius
- banktransfer
- ideal

Only available if transaction has status 'paid'

Refund costs are not available since they cannot be retrieved via any other API call

To use it, simply do:

> 	$payment = $mollie->payments->get($transaction_id);
> 	$payment_costs = $payment->getCosts()->payment;
> 	$refund_costs = $payment->getCosts()->refund; // Not yet supported

