### PR TITLE
Numerous Oauth testmode fixes and more

### DIFF
--- a/src/Endpoints/OrderEndpoint.php
+++ b/src/Endpoints/OrderEndpoint.php
@@ -85,12 +85,13 @@ class OrderEndpoint extends CollectionEndpointAbstract
      *
      * @param string $orderId
      *
+     * @param array $parameters
      * @return Order
-     * @throws ApiException
+     * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function cancel($orderId)
+    public function cancel($orderId, $parameters = [])
     {
-        return $this->rest_delete($orderId);
+        return $this->rest_delete($orderId, $parameters);
     }
 
     /**

--- a/src/Resources/Customer.php
+++ b/src/Resources/Customer.php
@@ -89,7 +89,7 @@ class Customer extends BaseResource
      */
     public function createPayment(array $options = [], array $filters = [])
     {
-        return $this->client->customerPayments->createFor($this, $options, $filters);
+        return $this->client->customerPayments->createFor($this, $this->withPresetOptions($options), $filters);
     }
 
     /**
@@ -110,7 +110,7 @@ class Customer extends BaseResource
      */
     public function createSubscription(array $options = [], array $filters = [])
     {
-        return $this->client->subscriptions->createFor($this, $options, $filters);
+        return $this->client->subscriptions->createFor($this, $this->withPresetOptions($options), $filters);
     }
 
     /**
@@ -121,7 +121,7 @@ class Customer extends BaseResource
      */
     public function getSubscription($subscriptionId, array $parameters = [])
     {
-        return $this->client->subscriptions->getFor($this, $subscriptionId, $parameters);
+        return $this->client->subscriptions->getFor($this, $subscriptionId, $this->withPresetOptions($parameters));
     }
 
     /**
@@ -152,7 +152,7 @@ class Customer extends BaseResource
      */
     public function createMandate(array $options = [], array $filters = [])
     {
-        return $this->client->mandates->createFor($this, $options, $filters);
+        return $this->client->mandates->createFor($this, $this->withPresetOptions($options), $filters);
     }
 
     /**
@@ -233,5 +233,16 @@ class Customer extends BaseResource
         }
 
         return $options;
+    }
+
+    /**
+     * Apply the preset options.
+     *
+     * @param array $options
+     * @return array
+     */
+    private function withPresetOptions(array $options)
+    {
+        return array_merge($this->getPresetOptions(), $options);
     }
 }

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -385,7 +385,7 @@ class Order extends BaseResource
      */
     public function refund(array $data)
     {
-        return $this->client->orderRefunds->createFor($this, $data);
+        return $this->client->orderRefunds->createFor($this, $this->withPresetOptions($data));
     }
 
     /**
@@ -397,6 +397,7 @@ class Order extends BaseResource
     public function refundAll(array $data = [])
     {
         $data['lines'] = [];
+
         return $this->refund($data);
     }
 
@@ -490,5 +491,16 @@ class Order extends BaseResource
         }
 
         return $options;
+    }
+
+    /**
+     * Apply the preset options.
+     *
+     * @param array $options
+     * @return array
+     */
+    private function withPresetOptions(array $options)
+    {
+        return array_merge($this->getPresetOptions(), $options);
     }
 }

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -266,7 +266,7 @@ class Order extends BaseResource
      */
     public function cancel()
     {
-        return $this->client->orders->cancel($this->id);
+        return $this->client->orders->cancel($this->id, $this->getPresetOptions());
     }
 
     /**
@@ -475,5 +475,20 @@ class Order extends BaseResource
             $this->_embedded->payments,
             Payment::class
         );
+    }
+
+    /**
+     * When accessed by oAuth we want to pass the testmode by default
+     *
+     * @return array
+     */
+    private function getPresetOptions()
+    {
+        $options = [];
+        if($this->client->usesOAuth()) {
+            $options["testmode"] = $this->mode === "test" ? true : false;
+        }
+
+        return $options;
     }
 }

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -322,7 +322,7 @@ class Order extends BaseResource
      */
     public function createShipment(array $options = [])
     {
-        return $this->client->shipments->createFor($this, $options);
+        return $this->client->shipments->createFor($this, $this->withPresetOptions($options));
     }
 
     /**
@@ -348,7 +348,7 @@ class Order extends BaseResource
      */
     public function getShipment($shipmentId, array $parameters = [])
     {
-        return $this->client->shipments->getFor($this, $shipmentId, $parameters);
+        return $this->client->shipments->getFor($this, $shipmentId, $this->withPresetOptions($parameters));
     }
 
     /**
@@ -360,7 +360,7 @@ class Order extends BaseResource
      */
     public function shipments(array $parameters = [])
     {
-        return $this->client->shipments->listFor($this, $parameters);
+        return $this->client->shipments->listFor($this, $this->withPresetOptions($parameters));
     }
 
     /**

--- a/src/Resources/OrderLine.php
+++ b/src/Resources/OrderLine.php
@@ -135,6 +135,11 @@ class OrderLine extends BaseResource
     public $createdAt;
 
     /**
+     * @var \stdClass
+     */
+    public $_links;
+
+    /**
      * Is this order line created?
      *
      * @return bool
@@ -275,4 +280,24 @@ class OrderLine extends BaseResource
         return $this->type === OrderLineType::TYPE_SURCHARGE;
     }
 
+    public function update()
+    {
+        $body = json_encode(array(
+            "name" => $this->name,
+            'imageUrl' => $this->imageUrl,
+            'productUrl' => $this->productUrl,
+            'quantity' => $this->quantity,
+            'unitPrice' => $this->unitPrice,
+            'discountAmount' => $this->discountAmount,
+            'totalAmount' => $this->totalAmount,
+            'vatAmount' => $this->vatAmount,
+            'vatRate' => $this->vatRate,
+        ));
+
+        $url="orders/{$this->orderId}/lines/{$this->id}";
+
+        $result = $this->client->performHttpCall(MollieApiClient::HTTP_PATCH, $url, $body);
+
+        return ResourceFactory::createFromApiResult($result, new Order($this->client));
+    }
 }

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -440,7 +440,7 @@ class Payment extends BaseResource
      */
     public function getRefund($refundId, array $parameters = [])
     {
-        return $this->client->paymentRefunds->getFor($this, $refundId, $parameters);
+        return $this->client->paymentRefunds->getFor($this, $refundId, $this->withPresetOptions($parameters));
     }
 
     /**
@@ -540,6 +540,7 @@ class Payment extends BaseResource
     {
         $resource = "payments/" . urlencode($this->id) . "/refunds";
 
+        $data = $this->withPresetOptions($data);
         $body = null;
         if (count($data) > 0) {
             $body = json_encode($data);

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -479,7 +479,7 @@ class Payment extends BaseResource
         return $this->client->paymentCaptures->getFor(
             $this,
             $captureId,
-            $parameters
+            $this->withPresetOptions($parameters)
         );
     }
 
@@ -521,7 +521,7 @@ class Payment extends BaseResource
         return $this->client->paymentChargebacks->getFor(
             $this,
             $chargebackId,
-            $parameters
+            $this->withPresetOptions($parameters)
         );
     }
 
@@ -578,5 +578,31 @@ class Payment extends BaseResource
         );
 
         return ResourceFactory::createFromApiResult($result, new Payment($this->client));
+    }
+
+    /**
+     * When accessed by oAuth we want to pass the testmode by default
+     *
+     * @return array
+     */
+    private function getPresetOptions()
+    {
+        $options = [];
+        if($this->client->usesOAuth()) {
+            $options["testmode"] = $this->mode === "test" ? true : false;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Apply the preset options.
+     *
+     * @param array $options
+     * @return array
+     */
+    private function withPresetOptions(array $options)
+    {
+        return array_merge($this->getPresetOptions(), $options);
     }
 }

--- a/tests/Mollie/API/Endpoints/OrderEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OrderEndpointTest.php
@@ -758,11 +758,7 @@ class OrderEndpointTest extends BaseEndpointTest
                      }
                }'
             ),
-            new Response(
-                200,
-                [],
-                $this->getOrderResponseFixture('ord_pbjz8x')
-            )
+            new Response(200, [], $this->getOrderResponseFixture('ord_pbjz8x'))
         );
 
         $orderLine = new OrderLine($this->apiClient);
@@ -773,22 +769,10 @@ class OrderEndpointTest extends BaseEndpointTest
         $orderLine->imageUrl = 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$';
         $orderLine->quantity = 2;
         $orderLine->vatRate = '21.00';
-        $orderLine->unitPrice = (object) [
-            'currency' => 'EUR',
-            'value' => '349.00',
-        ];
-        $orderLine->totalAmount = (object) [
-            'currency' => 'EUR',
-            'value' => '598.00',
-        ];
-        $orderLine->discountAmount = (object) [
-            'currency' => 'EUR',
-            'value' => '100.00',
-        ];
-        $orderLine->vatAmount = (object) [
-            'currency' => 'EUR',
-            'value' => '103.79',
-        ];
+        $orderLine->unitPrice = (object) ['currency' => 'EUR','value' => '349.00'];
+        $orderLine->totalAmount = (object) ['currency' => 'EUR','value' => '598.00'];
+        $orderLine->discountAmount = (object) ['currency' => 'EUR','value' => '100.00'];
+        $orderLine->vatAmount = (object) ['currency' => 'EUR','value' => '103.79'];
 
         $result = $orderLine->update();
 

--- a/tests/Mollie/API/Endpoints/OrderEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OrderEndpointTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Mollie\Api\Resources\Order;
 use Mollie\Api\Resources\OrderCollection;
+use Mollie\Api\Resources\OrderLine;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Resources\PaymentCollection;
 use Mollie\Api\Resources\Shipment;
@@ -724,6 +725,74 @@ class OrderEndpointTest extends BaseEndpointTest
         $order = $order->update();
 
         $this->assertOrder($order, "ord_pbjz8x", OrderStatus::STATUS_CREATED, "16738");
+    }
+
+    public function testUpdateOrderLine()
+    {
+        $this->mockApiCall(
+            new Request(
+                "PATCH",
+                "/v2/orders/ord_pbjz8x/lines/odl_dgtxyl",
+                [],
+                '{
+                     "name": "LEGO 71043 Hogwarts™ Castle",
+                     "productUrl": "https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043",
+                     "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$",
+                     "quantity": 2,
+                     "vatRate": "21.00",
+                     "unitPrice": {
+                        "currency": "EUR",
+                        "value": "349.00"
+                     },
+                     "totalAmount": {
+                        "currency": "EUR",
+                        "value": "598.00"
+                     },
+                     "discountAmount": {
+                        "currency": "EUR",
+                        "value": "100.00"
+                     },
+                     "vatAmount": {
+                        "currency": "EUR",
+                        "value": "103.79"
+                     }
+               }'
+            ),
+            new Response(
+                200,
+                [],
+                $this->getOrderResponseFixture('ord_pbjz8x')
+            )
+        );
+
+        $orderLine = new OrderLine($this->apiClient);
+        $orderLine->id = 'odl_dgtxyl';
+        $orderLine->orderId = 'ord_pbjz8x';
+        $orderLine->name = 'LEGO 71043 Hogwarts™ Castle';
+        $orderLine->productUrl = 'https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043';
+        $orderLine->imageUrl = 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$';
+        $orderLine->quantity = 2;
+        $orderLine->vatRate = '21.00';
+        $orderLine->unitPrice = (object) [
+            'currency' => 'EUR',
+            'value' => '349.00',
+        ];
+        $orderLine->totalAmount = (object) [
+            'currency' => 'EUR',
+            'value' => '598.00',
+        ];
+        $orderLine->discountAmount = (object) [
+            'currency' => 'EUR',
+            'value' => '100.00',
+        ];
+        $orderLine->vatAmount = (object) [
+            'currency' => 'EUR',
+            'value' => '103.79',
+        ];
+
+        $result = $orderLine->update();
+
+        $this->assertOrder($result, 'ord_pbjz8x');
     }
 
     protected function assertOrder($order, $order_id, $order_status = OrderStatus::STATUS_CREATED, $orderNumber = "1337")


### PR DESCRIPTION
**Modified**

Are you using OAuth ( also known as Mollie Connect) in test mode?

Calls made from retrieved resources no longer require you to explicitly set `['testmode' => true]`. (But things will continue to work if you do.)

Changes include:

- Customer methods `update()`, `payments()`, `createSubscription()` and `subscriptions()`.
- Order methods `cancel()`, `createShipment()`, `getShipment()`, `shipAll()`, `shipments()`, `refund()`, `refundAll`
- Payment methods `getRefund()`, `getCapture()`, `getChargeback()`, `refund()`

**Added**

- `OrderLine.update()` for updating a single `OrderLine`. (No OAuth testmode support yet.)