### PR TITLE
Update PHPDoc for MethodPrice.php

### DIFF
--- a/src/Resources/MethodPrice.php
+++ b/src/Resources/MethodPrice.php
@@ -8,7 +8,7 @@ class MethodPrice extends BaseResource
      * The area or product-type where the pricing is applied for, translated in the optional locale passed.
      *
      * @example "The Netherlands"
-     * @var \stdClass
+     * @var string
      */
     public $description;
 
@@ -22,7 +22,7 @@ class MethodPrice extends BaseResource
     /**
      * A string containing the percentage being charged over the payment amount besides the fixed price.
      *
-     * @var \stdClass An amount object consisting of `value` and `currency`
+     * @var string An string representing the percentage as a float (for example: "0.1" for 10%)
      */
     public $variable;
 }


### PR DESCRIPTION
Fix for invalid PHPDoc in the MethodPrice class:

1. $description is a string, not a \stdClass object
2. $variable is a string representing a float, not a \stdClass object