### PR TITLE
Add metadata variable to the order line resource

### DIFF
--- a/src/Resources/OrderLine.php
+++ b/src/Resources/OrderLine.php
@@ -125,6 +125,14 @@ class OrderLine extends BaseResource
      * @var string|null
      */
     public $productUrl;
+    
+    /**
+     * During creation of the order you can set custom metadata on order lines that is stored with
+     * the order, and given back whenever you retrieve that order line.
+     *
+     * @var \stdClass|mixed|null
+     */
+    public $metadata;
 
     /**
      * The order line's date and time of creation, in ISO 8601 format.


### PR DESCRIPTION
The metadata variable is missing from the resource. As you can see in the documentation provided by Mollie (https://docs.mollie.com/reference/v2/orders-api/create-order#order-lines-details), metadata can also be set on an order line. And it will be returned by Mollie if you fetch an order line through the API.