### PR TITLE
Add dates to  order resource

### DIFF
--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -145,6 +145,54 @@ class Order extends BaseResource
     public $createdAt;
 
     /**
+     * UTC datetime the order the order will expire in ISO-8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $expiresAt;
+
+    /**
+     * UTC datetime if the order is expired, the time of expiration will be present in ISO-8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $expiredAt;
+
+    /**
+     * UTC datetime if the order has been paid, the time of payment will be present in ISO-8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $paidAt;
+
+    /**
+     * UTC datetime if the order has been authorized, the time of authorization will be present in ISO-8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $authorizedAt;
+
+    /**
+     * UTC datetime if the order has been canceled, the time of cancellation will be present in ISO 8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $canceledAt;
+
+    /**
+     * UTC datetime if the order is completed, the time of completion will be present in ISO 8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $completedAt;
+
+    /**
      * The order lines contain the actual things the customer bought.
      *
      * @var array|object[]

--- a/tests/Mollie/API/Endpoints/OrderEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/OrderEndpointTest.php
@@ -788,6 +788,7 @@ class OrderEndpointTest extends BaseEndpointTest
         $this->assertEquals('live', $order->mode);
         $this->assertEquals('klarnapaylater', $order->method);
         $this->assertEquals('2018-08-02T09:29:56+00:00', $order->createdAt);
+        $this->assertEquals('2018-09-02T09:29:56+00:00', $order->expiresAt);
 
         $this->assertAmountObject('1027.99', 'EUR', $order->amount);
         $this->assertAmountObject('0.00', 'EUR', $order->amountCaptured);
@@ -926,6 +927,7 @@ class OrderEndpointTest extends BaseEndpointTest
              },
              "consumerDateOfBirth": "1958-01-31",
              "createdAt": "2018-08-02T09:29:56+00:00",
+             "expiresAt": "2018-09-02T09:29:56+00:00",
              "mode": "live",
              "billingAddress": {
                  "organizationName": "Organization Name LTD.",


### PR DESCRIPTION
Added missing date fields in Order.php
And added an extra assertion to the order endpoint test so that it is in line with the payment endpoint tests.
Took the dates from [https://docs.mollie.com/reference/v2/orders-api/get-order#response](https://docs.mollie.com/reference/v2/orders-api/get-order#response).
