### PR TITLE
Add paypal to valid first payment methods

### DIFF
--- a/src/Types/MandateMethod.php
+++ b/src/Types/MandateMethod.php
@@ -6,9 +6,14 @@ class MandateMethod
 {
     const DIRECTDEBIT = "directdebit";
     const CREDITCARD = "creditcard";
+    const PAYPAL = "paypal";
 
     public static function getForFirstPaymentMethod($firstPaymentMethod)
     {
+        if ($firstPaymentMethod === PaymentMethod::PAYPAL) {
+            return static::PAYPAL;
+        }
+
         if(in_array($firstPaymentMethod, [
             PaymentMethod::APPLEPAY,
             PaymentMethod::CREDITCARD,

--- a/tests/Mollie/API/Types/MandateMethodTest.php
+++ b/tests/Mollie/API/Types/MandateMethodTest.php
@@ -32,6 +32,7 @@ class MandateMethodTest extends TestCase
             [PaymentMethod::INGHOMEPAY, MandateMethod::DIRECTDEBIT],
             [PaymentMethod::KBC, MandateMethod::DIRECTDEBIT],
             [PaymentMethod::SOFORT, MandateMethod::DIRECTDEBIT],
+            [PaymentMethod::PAYPAL, MandateMethod::PAYPAL],
         ];
     }
 }


### PR DESCRIPTION
As the API documentation states, it's possible to [create](https://docs.mollie.com/reference/v2/mandates-api/create-mandate) and [receive](https://docs.mollie.com/reference/v2/mandates-api/get-mandate) mandates with the method **paypal**.
Therefore this PR adds the payment method to the possible **MandateMethod** entries