### PR TITLE
Deploy using php5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    php: 7.4
+    php: 5.6


### PR DESCRIPTION
Relates to #488, #487, #486

Reverting to php5.6 deployment builds a .zip with Guzzle 6 - so the build should be compatible again with php5.6 and up.