### PR TITLE
Add missing constant and fix orderLine::update()

### DIFF
--- a/src/Resources/OrderLine.php
+++ b/src/Resources/OrderLine.php
@@ -295,6 +295,20 @@ class OrderLine extends BaseResource
      */
     public function update()
     {
+        $url="orders/{$this->orderId}/lines/{$this->id}";
+        $body = json_encode($this->getData());
+        $result = $this->client->performHttpCall(MollieApiClient::HTTP_PATCH, $url, $body);
+
+        return ResourceFactory::createFromApiResult($result, new Order($this->client));
+    }
+
+    /**
+     * Get sanitized array of order line data
+     *
+     * @return array
+     */
+    public function getData()
+    {
         $data = array(
             "name" => $this->name,
             'imageUrl' => $this->imageUrl,
@@ -309,12 +323,6 @@ class OrderLine extends BaseResource
         );
 
         // Explicitly filter only NULL values to keep "vatRate => 0" intact
-        $body = json_encode(array_filter($data, function($value) { return $value !== null; }));
-
-        $url="orders/{$this->orderId}/lines/{$this->id}";
-
-        $result = $this->client->performHttpCall(MollieApiClient::HTTP_PATCH, $url, $body);
-
-        return ResourceFactory::createFromApiResult($result, new Order($this->client));
+        return array_filter($data, function($value) { return $value !== null; });
     }
 }

--- a/src/Resources/OrderLine.php
+++ b/src/Resources/OrderLine.php
@@ -296,7 +296,7 @@ class OrderLine extends BaseResource
     public function update()
     {
         $url="orders/{$this->orderId}/lines/{$this->id}";
-        $body = json_encode($this->getData());
+        $body = json_encode($this->getUpdateData());
         $result = $this->client->performHttpCall(MollieApiClient::HTTP_PATCH, $url, $body);
 
         return ResourceFactory::createFromApiResult($result, new Order($this->client));
@@ -307,7 +307,7 @@ class OrderLine extends BaseResource
      *
      * @return array
      */
-    public function getData()
+    public function getUpdateData()
     {
         $data = array(
             "name" => $this->name,

--- a/src/Resources/OrderLine.php
+++ b/src/Resources/OrderLine.php
@@ -288,9 +288,14 @@ class OrderLine extends BaseResource
         return $this->type === OrderLineType::TYPE_SURCHARGE;
     }
 
+    /**
+     * Update an orderline by supplying one or more parameters in the data array
+     *
+     * @return BaseResource
+     */
     public function update()
     {
-        $body = json_encode(array(
+        $data = array(
             "name" => $this->name,
             'imageUrl' => $this->imageUrl,
             'productUrl' => $this->productUrl,
@@ -301,7 +306,10 @@ class OrderLine extends BaseResource
             'totalAmount' => $this->totalAmount,
             'vatAmount' => $this->vatAmount,
             'vatRate' => $this->vatRate,
-        ));
+        );
+
+        // Explicitly filter only NULL values to keep "vatRate => 0" intact
+        $body = json_encode(array_filter($data, function($value) { return $value !== null; }));
 
         $url="orders/{$this->orderId}/lines/{$this->id}";
 

--- a/src/Resources/Refund.php
+++ b/src/Resources/Refund.php
@@ -124,6 +124,16 @@ class Refund extends BaseResource
     }
 
     /**
+     * Is this refund failed?
+     *
+     * @return bool
+     */
+    public function isFailed()
+    {
+        return $this->status === RefundStatus::STATUS_FAILED;
+    }
+
+    /**
      * Cancel the refund.
      * Returns null if successful.
      *

--- a/src/Types/RefundStatus.php
+++ b/src/Types/RefundStatus.php
@@ -23,4 +23,9 @@ class RefundStatus
      * The refund amount has been transferred to the consumer.
      */
     const STATUS_REFUNDED = 'refunded';
+
+    /**
+     * The refund has failed after processing. For example, the customer has closed his / her bank account. The funds will be returned to your account.
+     */
+    const STATUS_FAILED = 'failed';
 }

--- a/tests/Mollie/API/Resources/OrderLineTest.php
+++ b/tests/Mollie/API/Resources/OrderLineTest.php
@@ -39,6 +39,29 @@ class OrderLineTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected_boolean, $orderLine->{$function}());
     }
 
+    /**
+     * @param $vatRate
+     * @param $expected_boolean
+     *
+     * @dataProvider dpTestUpdateVatRate
+     */
+    public function testUpdateVatRate($vatRate, $expected_boolean)
+    {
+        $orderLine = new OrderLine($this->createMock(MollieApiClient::class));
+        $orderLine->vatRate = $vatRate;
+
+        $this->assertEquals(isset($orderLine->getData()['vatRate']), $expected_boolean);
+    }
+
+    public function dpTestUpdateVatRate()
+    {
+        return [
+            [0, true],
+            ['0', true],
+            [null, false]
+        ];
+    }
+
     public function dpTestOrderLineTypes()
     {
         return [

--- a/tests/Mollie/API/Resources/OrderLineTest.php
+++ b/tests/Mollie/API/Resources/OrderLineTest.php
@@ -50,7 +50,7 @@ class OrderLineTest extends \PHPUnit\Framework\TestCase
         $orderLine = new OrderLine($this->createMock(MollieApiClient::class));
         $orderLine->vatRate = $vatRate;
 
-        $this->assertEquals(isset($orderLine->getData()['vatRate']), $expected_boolean);
+        $this->assertEquals(isset($orderLine->getUpdateData()['vatRate']), $expected_boolean);
     }
 
     public function dpTestUpdateVatRate()

--- a/tests/Mollie/API/Resources/RefundTest.php
+++ b/tests/Mollie/API/Resources/RefundTest.php
@@ -30,21 +30,31 @@ class RefundTest extends \PHPUnit\Framework\TestCase
             [RefundStatus::STATUS_PENDING, "isProcessing", false],
             [RefundStatus::STATUS_PENDING, "isQueued", false],
             [RefundStatus::STATUS_PENDING, "isTransferred", false],
+            [RefundStatus::STATUS_PENDING, "isFailed", false],
 
             [RefundStatus::STATUS_PROCESSING, "isPending", false],
             [RefundStatus::STATUS_PROCESSING, "isProcessing", true],
             [RefundStatus::STATUS_PROCESSING, "isQueued", false],
             [RefundStatus::STATUS_PROCESSING, "isTransferred", false],
+            [RefundStatus::STATUS_PROCESSING, "isFailed", false],
 
             [RefundStatus::STATUS_QUEUED, "isPending", false],
             [RefundStatus::STATUS_QUEUED, "isProcessing", false],
             [RefundStatus::STATUS_QUEUED, "isQueued", true],
             [RefundStatus::STATUS_QUEUED, "isTransferred", false],
+            [RefundStatus::STATUS_QUEUED, "isFailed", false],
 
             [RefundStatus::STATUS_REFUNDED, "isPending", false],
             [RefundStatus::STATUS_REFUNDED, "isProcessing", false],
             [RefundStatus::STATUS_REFUNDED, "isQueued", false],
             [RefundStatus::STATUS_REFUNDED, "isTransferred", true],
+            [RefundStatus::STATUS_REFUNDED, "isFailed", false],
+
+            [RefundStatus::STATUS_FAILED, "isPending", false],
+            [RefundStatus::STATUS_FAILED, "isProcessing", false],
+            [RefundStatus::STATUS_FAILED, "isQueued", false],
+            [RefundStatus::STATUS_FAILED, "isTransferred", false],
+            [RefundStatus::STATUS_FAILED, "isFailed", true],
         ];
     }
 }


### PR DESCRIPTION
- Constant for "failed" refunds was missing
- OrderLine update didn't work when passing empty (null) parameters