### PR TITLE
Fixed PaymentMethodStatus::PENDING_ONBOARDING

### DIFF
--- a/src/Types/PaymentMethodStatus.php
+++ b/src/Types/PaymentMethodStatus.php
@@ -17,7 +17,7 @@ class PaymentMethodStatus
      *
      * @link https://docs.mollie.com/reference/v2/methods-api/get-method#parameters
      */
-    const PENDING_ONBOARDING = "pending-onboarding";
+    const PENDING_ONBOARDING = "pending-boarding";
 
     /**
      * Mollie needs to review your request for this payment method before it can be activated.


### PR DESCRIPTION
Hi, according to the [docs](https://docs.mollie.com/reference/v2/methods-api/get-method#parameters ) the status `PENDING_ONBOARDING` should have the value `pending-boarding`.