### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 /.gitignore export-ignore
 /phpunit.xml export-ignore
 /scoper.inc.php export-ignore
+/examples export-ignore
+/.php_cs export-ignore
+/phpstan.neon export-ignore


### PR DESCRIPTION
We don't need the `examples` folder in production. 
Added `.php_cs` and `phpstan.neon` as well.