### PR TITLE
Workaround for testmode query param on cancel subscription call

### DIFF
--- a/src/Resources/Subscription.php
+++ b/src/Resources/Subscription.php
@@ -96,7 +96,7 @@ class Subscription extends BaseResource
      * @var \stdClass|null
      */
     public $webhookUrl;
-    
+
     /**
      * Date the next subscription payment will take place. For example: 2018-04-24
      *
@@ -207,9 +207,12 @@ class Subscription extends BaseResource
             ]);
         }
 
+        // endpoint does not support 'testmode' as a query param, so we need to strip it from the url
+        $url = str_replace('?testmode=true', '', $this->_links->self->href);
+
         $result = $this->client->performHttpCallToFullUrl(
             MollieApiClient::HTTP_DELETE,
-            $this->_links->self->href,
+            $url,
             $body
         );
 

--- a/src/Resources/Subscription.php
+++ b/src/Resources/Subscription.php
@@ -208,7 +208,7 @@ class Subscription extends BaseResource
         }
 
         // endpoint does not support 'testmode' as a query param, so we need to strip it from the url
-        $url = str_replace('?testmode=true', '', $this->_links->self->href);
+        $url = str_replace(['?testmode=true', '?testmode=false'], '', $this->_links->self->href);
 
         $result = $this->client->performHttpCallToFullUrl(
             MollieApiClient::HTTP_DELETE,


### PR DESCRIPTION
Hi,

I've left a comment on #437 and this pull request contains a workaround for the `Error executing API call (422: Unprocessable Entity): Non-existent query parameter "testmode" for this API call.. Field: testmode` exception on the subscription->cancel() call.

In https://github.com/mollie/mollie-api-php/issues/437#issuecomment-580770762 it's mentioned that Mollie is accepting the `testmode` query parameter on the other endpoints, and I think adding this support also to the cancel subscription endpoint would be a better solution than merging this workaround.