### PR TITLE
Bugfix: Add missing return type

### DIFF
--- a/src/Endpoints/MandateEndpoint.php
+++ b/src/Endpoints/MandateEndpoint.php
@@ -79,7 +79,7 @@ class MandateEndpoint extends CollectionEndpointAbstract
      * @param string $mandateId
      * @param array $parameters
      *
-     * @return \Mollie\Api\Resources\BaseResource
+     * @return \Mollie\Api\Resources\BaseResource|\Mollie\Api\Resources\Mandate
      * @throws \Mollie\Api\Exceptions\ApiException
      */
     public function getForId($customerId, $mandateId, array $parameters = [])


### PR DESCRIPTION
The `\Mollie\Api\Endpoints\MandateEndpoint::getForId()` function is missing the correct return type, I've added it.