### PR TITLE
Change the PHPDoc for the subscription metadata

### DIFF
--- a/src/Resources/Subscription.php
+++ b/src/Resources/Subscription.php
@@ -72,7 +72,7 @@ class Subscription extends BaseResource
     public $mandateId;
 
     /**
-     * @var array|null
+     * @var \stdClass|null
      */
     public $metadata;
 


### PR DESCRIPTION
The PHPDoc states that it contains an array, but it's actually a stdClass object.