### PR TITLE
Add JSON content type to request

### DIFF
--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -482,8 +482,11 @@ class MollieApiClient
             'Accept' => "application/json",
             'Authorization' => "Bearer {$this->apiKey}",
             'User-Agent' => $userAgent,
-            'Content-Type' => "application/json",
         ];
+
+        if ($httpBody !== null) {
+            $headers['Content-type'] = "application/json";
+        }
 
         if (function_exists("php_uname")) {
             $headers['X-Mollie-Client-Info'] = php_uname();

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -482,6 +482,7 @@ class MollieApiClient
             'Accept' => "application/json",
             'Authorization' => "Bearer {$this->apiKey}",
             'User-Agent' => $userAgent,
+            'Content-Type' => "application/json",
         ];
 
         if (function_exists("php_uname")) {


### PR DESCRIPTION
In https://github.com/mollie/mollie-api-php/blob/c1a500d251255e29919c6250d5c741ae4fe4e178/src/Endpoints/EndpointAbstract.php#L207-L211 we encode all data thrown into the endpoints as JSON. It would make sense to set an appropriate `Content-Type` header in this case, not only because it would be correct, but also because it eases handling when tunnelling API requests to Mollie through e.g. `ngrok` to analyze what exactly is happening.

Before:
![image](https://user-images.githubusercontent.com/7370694/118653397-c5df3480-b7e7-11eb-9711-ed9f06d4af0e.png)

After:
![image](https://user-images.githubusercontent.com/7370694/118653445-d2638d00-b7e7-11eb-96d5-a3e169a366dc.png)

Caveats:
- ~~This hack also sets the `Content-Type` header for GET requests (e.g. `$mollie->payments->get('tr_12345')`), which is not explicitly forbidden but also not explicitly allowed in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5)~~
- I have not tested each and every request to Mollie