### PR TITLE
NTR: add correct content type application/json

### DIFF
--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -450,6 +450,10 @@ class MollieApiClient
             'User-Agent' => $userAgent,
         ];
 
+        if ($httpBody !== null) {
+            $headers['Content-Type'] = "application/json";
+        }
+
         if (function_exists("php_uname")) {
             $headers['X-Mollie-Client-Info'] = php_uname();
         }

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Mollie\Api;
 
 use Eloquent\Liberator\Liberator;
@@ -8,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\HttpAdapter\Guzzle6And7MollieHttpAdapter;
 use Mollie\Api\MollieApiClient;
+use Tests\Mollie\TestHelpers\FakeHttpAdapter;
 
 class MollieApiClientTest extends \PHPUnit\Framework\TestCase
 {
@@ -138,7 +140,7 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
         $response = new Response(200, [], '{"resource": "payment"}');
 
         // Before the MollieApiClient gets the response, some middleware reads the body first.
-        $bodyAsReadFromMiddleware = (string) $response->getBody();
+        $bodyAsReadFromMiddleware = (string)$response->getBody();
 
         $this->guzzleClient
             ->expects($this->once())
@@ -157,4 +159,56 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
             $parsedResponse
         );
     }
+
+    /**
+     * This test verifies that our request headers are correctly sent to Mollie.
+     * If these are broken, it could be that some payments do not work.
+     *
+     * @throws ApiException
+     */
+    public function testCorrectRequestHeaders()
+    {
+        $response = new Response(200, [], '{"resource": "payment"}');
+        $fakeAdapter = new FakeHttpAdapter($response);
+
+        $mollieClient = new MollieApiClient($fakeAdapter);
+        $mollieClient->setApiKey('test_foobarfoobarfoobarfoobarfoobar');
+
+        $mollieClient->performHttpCallToFullUrl('GET', '', '');
+
+        $usedHeaders = $fakeAdapter->getUsedHeaders();
+
+        # these change through environments
+        # just make sure its existing
+        $this->assertArrayHasKey('User-Agent', $usedHeaders);
+        $this->assertArrayHasKey('X-Mollie-Client-Info', $usedHeaders);
+
+        # these should be exactly the expected values
+        $this->assertEquals('Bearer test_foobarfoobarfoobarfoobarfoobar', $usedHeaders['Authorization']);
+        $this->assertEquals('application/json', $usedHeaders['Accept']);
+        $this->assertEquals('application/json', $usedHeaders['Content-Type']);
+    }
+
+    /**
+     * This test verifies that we do not add a Content-Type request header
+     * if we do not send a BODY (skipping argument).
+     * In this case it has to be skipped.
+     *
+     * @throws ApiException
+     * @throws \Mollie\Api\Exceptions\IncompatiblePlatform
+     * @throws \Mollie\Api\Exceptions\UnrecognizedClientException
+     */
+    public function testNoContentTypeWithoutProvidedBody()
+    {
+        $response = new Response(200, [], '{"resource": "payment"}');
+        $fakeAdapter = new FakeHttpAdapter($response);
+
+        $mollieClient = new MollieApiClient($fakeAdapter);
+        $mollieClient->setApiKey('test_foobarfoobarfoobarfoobarfoobar');
+
+        $mollieClient->performHttpCallToFullUrl('GET', '');
+
+        $this->assertEquals(false, isset($fakeAdapter->getUsedHeaders()['Content-Type']));
+    }
+
 }

--- a/tests/Mollie/TestHelpers/FakeHttpAdapter.php
+++ b/tests/Mollie/TestHelpers/FakeHttpAdapter.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Mollie\TestHelpers;
+
+use Mollie\Api\HttpAdapter\MollieHttpAdapterInterface;
+
+class FakeHttpAdapter implements MollieHttpAdapterInterface
+{
+
+    /**
+     * @var \stdClass|null
+     */
+    private $response;
+
+    /**
+     * @var string
+     */
+    private $usedMethod;
+
+    /**
+     * @var string
+     */
+    private $usedUrl;
+
+    /**
+     * @var string
+     */
+    private $usedHeaders;
+
+    /**
+     * @var string
+     */
+    private $usedBody;
+
+
+    /**
+     * FakeHttpAdapter constructor.
+     * @param $response
+     */
+    public function __construct($response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @param $httpMethod
+     * @param $url
+     * @param $headers
+     * @param $httpBody
+     * @return \stdClass|void|null
+     */
+    public function send($httpMethod, $url, $headers, $httpBody)
+    {
+        $this->usedMethod = $httpMethod;
+        $this->usedUrl = $url;
+        $this->usedHeaders = $headers;
+        $this->usedBody = $httpBody;
+
+        return $this->response;
+    }
+
+    /**
+     * @return string
+     */
+    public function versionString()
+    {
+        return 'fake';
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUsedMethod()
+    {
+        return $this->usedMethod;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUsedUrl()
+    {
+        return $this->usedUrl;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUsedHeaders()
+    {
+        return $this->usedHeaders;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUsedBody()
+    {
+        return $this->usedBody;
+    }
+
+}


### PR DESCRIPTION
content type was wrong.
It has a lower case "type" instead of "Type"

"Content-type" -> "Content-Type"

i did also create unit tests for the headers.
the guzzle though wasnt possible to mock with "->with" (always wrong numbers of parameters).
so i've created a small fake class, which is (at least i think) better anyway

i have 2 unit tests with 2 newables of that new client, i didnt want to screw up anything
by putting it into the global setUp...hope thats ok