### PR TITLE
Add update method to PaymentEndpoint

### DIFF
--- a/examples/payments/update-payment.php
+++ b/examples/payments/update-payment.php
@@ -21,17 +21,17 @@ try {
 
 
     $payment = $mollie->payments->get("tr_7UhSN1zuXS");
-
-    $payment->description = "Order #98765";
+    $newOrderId = 98765;
+    $payment->description = "Order #".$newOrderId;
     $payment->redirectUrl = "https://example.org/webshop/order/98765/";
     $payment->webhookUrl = "https://example.org/webshop/payments/webhook/";
-    $payment->metadata = ["order_id" => "98765"];
+    $payment->metadata = ["order_id" => $newOrderId];
 
     $payment = $payment->update();
     /*
      * In this example we store the order with its payment status in a database.
      */
-    database_write($orderId, $payment->status);
+    database_write($newOrderId, $payment->status);
 
     /*
      * Send the customer off to complete the payment.

--- a/examples/payments/update-payment.php
+++ b/examples/payments/update-payment.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * How to prepare a new payment with the Mollie API.
+ */
+
+try {
+    /*
+     * Initialize the Mollie API library with your API key.
+     *
+     * See: https://www.mollie.com/dashboard/developers/api-keys
+     */
+    require "../initialize.php";
+
+    /*
+     * Payment parameters:
+     *   description   Description of the payment.
+     *   redirectUrl   Redirect location. The customer will be redirected there after the payment.
+     *   webhookUrl    Webhook location, used to report when the payment changes state.
+     *   metadata      Custom metadata that is stored with the payment.
+     */
+
+
+    $payment = $mollie->payments->get("tr_7UhSN1zuXS");
+
+    $payment->description = "Order #98765";
+    $payment->redirectUrl = "https://example.org/webshop/order/98765/";
+    $payment->webhookUrl = "https://example.org/webshop/payments/webhook/";
+    $payment->metadata = ["order_id" => "98765"];
+
+    $payment = $payment->update();
+    /*
+     * In this example we store the order with its payment status in a database.
+     */
+    database_write($orderId, $payment->status);
+
+    /*
+     * Send the customer off to complete the payment.
+     * This request should always be a GET, thus we enforce 303 http response code
+     */
+    header("Location: " . $payment->getCheckoutUrl(), true, 303);
+} catch (\Mollie\Api\Exceptions\ApiException $e) {
+    echo "API call failed: " . htmlspecialchars($e->getMessage());
+}

--- a/src/Endpoints/EndpointAbstract.php
+++ b/src/Endpoints/EndpointAbstract.php
@@ -80,6 +80,35 @@ abstract class EndpointAbstract
     }
 
     /**
+     * Sends a PATCH request to a single Molle API object.
+     *
+     * @param string $id
+     * @param array $body
+     *
+     * @return BaseResource
+     * @throws ApiException
+     */
+    protected function rest_update($id, array $body = [])
+    {
+        if (empty($id)) {
+            throw new ApiException("Invalid resource id.");
+        }
+
+        $id = urlencode($id);
+        $result = $this->client->performHttpCall(
+            self::REST_UPDATE,
+            "{$this->getResourcePath()}/{$id}",
+            $this->parseRequestBody($body)
+        );
+
+        if ($result === null) {
+            return null;
+        }
+
+        return ResourceFactory::createFromApiResult($result, $this->getResourceObject());
+    }
+
+    /**
      * Retrieves a single object from the REST API.
      *
      * @param string $id Id of the object to retrieve.

--- a/src/Endpoints/PaymentEndpoint.php
+++ b/src/Endpoints/PaymentEndpoint.php
@@ -53,6 +53,26 @@ class PaymentEndpoint extends CollectionEndpointAbstract
     }
 
     /**
+     * Update the given Payment.
+     *
+     * Will throw a ApiException if the payment id is invalid or the resource cannot be found.
+     *
+     * @param string $paymentId
+     *
+     * @param array $data
+     * @return Payment
+     * @throws ApiException
+     */
+    public function update($paymentId, array $data = [])
+    {
+        if (empty($paymentId) || strpos($paymentId, self::RESOURCE_ID_PREFIX) !== 0) {
+            throw new ApiException("Invalid payment ID: '{$paymentId}'. A payment ID should start with '".self::RESOURCE_ID_PREFIX."'.");
+        }
+
+        return parent::rest_update($paymentId, $data);
+    }
+
+    /**
      * Retrieve a single payment from Mollie.
      *
      * Will throw a ApiException if the payment id is invalid or the resource cannot be found.

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -646,10 +646,6 @@ class Payment extends BaseResource
 
     public function update()
     {
-        if (! isset($this->_links->self->href)) {
-            return $this;
-        }
-
         $body = [
             "description" => $this->description,
             "redirectUrl" => $this->redirectUrl,

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -649,21 +649,17 @@ class Payment extends BaseResource
         if (! isset($this->_links->self->href)) {
             return $this;
         }
-        
-        $body = json_encode([
+
+        $body = [
             "description" => $this->description,
             "redirectUrl" => $this->redirectUrl,
             "webhookUrl" => $this->webhookUrl,
             "metadata" => $this->metadata,
             "restrictPaymentMethodsToCountry" => $this->restrictPaymentMethodsToCountry,
-            "dueDate" => $this->dueDate,
-        ]);
+            "locale" => $this->locale
+        ];
 
-        $result = $this->client->performHttpCallToFullUrl(
-            MollieApiClient::HTTP_PATCH,
-            $this->_links->self->href,
-            $body
-        );
+        $result = $this->client->payments->update($this->id, $body);
 
         return ResourceFactory::createFromApiResult($result, new Payment($this->client));
     }

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -656,7 +656,8 @@ class Payment extends BaseResource
             "webhookUrl" => $this->webhookUrl,
             "metadata" => $this->metadata,
             "restrictPaymentMethodsToCountry" => $this->restrictPaymentMethodsToCountry,
-            "locale" => $this->locale
+            "locale" => $this->locale,
+            "dueDate" => $this->dueDate
         ];
 
         $result = $this->client->payments->update($this->id, $body);

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -657,7 +657,7 @@ class Payment extends BaseResource
             "metadata" => $this->metadata,
             "restrictPaymentMethodsToCountry" => $this->restrictPaymentMethodsToCountry,
             "locale" => $this->locale,
-            "dueDate" => $this->dueDate
+            "dueDate" => $this->dueDate,
         ];
 
         $result = $this->client->payments->update($this->id, $body);

--- a/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/PaymentEndpointTest.php
@@ -138,7 +138,8 @@ class PaymentEndpointTest extends BaseEndpointTest
                     "metadata":{
                         "order_id":"98765"
                     },
-                    "dueDate":null
+                    "dueDate":null,
+                    "locale":null
                 }'
             ),
             new Response(


### PR DESCRIPTION
- Add `rest_update`  to `EndpointAbstract.php`
- Add example for update method
- Refactor Payment resource to use the new PaymentEndpoint.update() method