### PR TITLE
Added `getAmountChargedBack` to payment resource

### DIFF
--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -497,6 +497,21 @@ class Payment extends BaseResource
     }
 
     /**
+     * Get the total amount that was charged back for this payment. Only available when the
+     * total charged back amount is not zero.
+     *
+     * @return float
+     */
+    public function getAmountChargedBack()
+    {
+        if ($this->amountChargedBack) {
+            return (float)$this->amountChargedBack->value;
+        }
+
+        return 0.0;
+    }
+
+    /**
      * Does the payment have split payments
      *
      * @return bool

--- a/tests/Mollie/API/Resources/PaymentTest.php
+++ b/tests/Mollie/API/Resources/PaymentTest.php
@@ -210,6 +210,22 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
         self::assertSame(0.0, $payment->getAmountRemaining());
     }
 
+    public function testGetAmountChargedBackReturnsAmountChargedBackAsFloat()
+    {
+        $payment = new Payment($this->createMock(MollieApiClient::class));
+
+        $payment->amountChargedBack = (object)["value" => 22.0, "currency" => "EUR"];
+        self::assertSame(22.0, $payment->getAmountChargedBack());
+    }
+
+    public function testGetAmountChargedBackReturns0WhenAmountChargedBackIsSetToNull()
+    {
+        $payment = new Payment($this->createMock(MollieApiClient::class));
+
+        $payment->amountChargedBack = null;
+        self::assertSame(0.0, $payment->getAmountChargedBack());
+    }
+
     public function testGetSettlementAmountReturns0WhenSettlementAmountIsSetToNull()
     {
         $payment = new Payment($this->createMock(MollieApiClient::class));


### PR DESCRIPTION
I noticed that the other amounts had this kind of method, but it was missing for the charged back amount.