### PR TITLE
Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,37 @@ $refund = $payment->refund([
 
 For a working example, see [Example - Refund payment](https://github.com/mollie/mollie-api-php/blob/master/examples/payments/refund-payment.php).
 
+## Enabling debug mode
+
+When debugging it can be convenient to have the submitted request available on the `ApiException`.
+
+In order to prevent leaking sensitive request data into your local application logs, debugging is disabled by default.
+
+To enable debugging and inspect the request: 
+
+```php
+/** @var $mollie \Mollie\Api\MollieApiClient */
+$mollie->enableDebugging();
+
+try {
+    $mollie->payments->get('tr_12345678');
+} catch (\Mollie\Api\Exceptions\ApiException $exception) {
+    $request = $exception->getRequest();
+}
+```
+
+If you're logging the `ApiException`, the request will also be logged. Make sure to not retain any sensitive data in
+these logs and clean up after debugging.
+
+To disable debugging again:
+
+```php
+/** @var $mollie \Mollie\Api\MollieApiClient */
+$mollie->disableDebugging();
+```
+
+Note that debugging is only available when using the default Guzzle http adapter (`Guzzle6And7MollieHttpAdapter`).
+
 ## API documentation ##
 If you wish to learn more about our API, please visit the [Mollie Developer Portal](https://www.mollie.com/developers). API Documentation is available in English.
 

--- a/src/Exceptions/HttpAdapterDoesNotSupportDebuggingException.php
+++ b/src/Exceptions/HttpAdapterDoesNotSupportDebuggingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mollie\Api\Exceptions;
+
+class HttpAdapterDoesNotSupportDebuggingException extends ApiException
+{
+}

--- a/src/HttpAdapter/CurlMollieHttpAdapter.php
+++ b/src/HttpAdapter/CurlMollieHttpAdapter.php
@@ -90,6 +90,17 @@ final class CurlMollieHttpAdapter implements MollieHttpAdapterInterface
     }
 
     /**
+     * Whether this http adapter provides a debugging mode. If debugging mode is enabled, the
+     * request will be included in the ApiException.
+     *
+     * @return false
+     */
+    public function supportsDebugging()
+    {
+        return false;
+    }
+
+    /**
      * @param string $response
      * @param int $statusCode
      * @param string $httpBody

--- a/src/HttpAdapter/Guzzle6And7MollieHttpAdapter.php
+++ b/src/HttpAdapter/Guzzle6And7MollieHttpAdapter.php
@@ -34,6 +34,15 @@ final class Guzzle6And7MollieHttpAdapter implements MollieHttpAdapterInterface
      */
     protected $httpClient;
 
+    /**
+     * Whether debugging is enabled. If debugging mode is enabled, the request will
+     * be included in the ApiException. By default, debugging is disabled to prevent
+     * sensitive request data from leaking into exception logs.
+     *
+     * @var bool
+     */
+    protected $debugging = false;
+
     public function __construct(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
@@ -77,6 +86,10 @@ final class Guzzle6And7MollieHttpAdapter implements MollieHttpAdapterInterface
         try {
             $response = $this->httpClient->send($request, ['http_errors' => false]);
         } catch (GuzzleException $e) {
+            // Prevent sensitive request data from ending up in exception logs unintended
+            if (! $this->debugging) {
+                $request = null;
+            }
 
             // Not all Guzzle Exceptions implement hasResponse() / getResponse()
             if (method_exists($e, 'hasResponse') && method_exists($e, 'getResponse')) {
@@ -93,6 +106,49 @@ final class Guzzle6And7MollieHttpAdapter implements MollieHttpAdapterInterface
         }
 
         return $this->parseResponseBody($response);
+    }
+
+    /**
+     * Whether this http adapter provides a debugging mode. If debugging mode is enabled, the
+     * request will be included in the ApiException.
+     *
+     * @return true
+     */
+    public function supportsDebugging()
+    {
+        return true;
+    }
+
+    /**
+     * Whether debugging is enabled. If debugging mode is enabled, the request will
+     * be included in the ApiException. By default, debugging is disabled to prevent
+     * sensitive request data from leaking into exception logs.
+     *
+     * @return bool
+     */
+    public function debugging()
+    {
+        return $this->debugging;
+    }
+
+    /**
+     * Enable debugging. If debugging mode is enabled, the request will
+     * be included in the ApiException. By default, debugging is disabled to prevent
+     * sensitive request data from leaking into exception logs.
+     */
+    public function enableDebugging()
+    {
+        $this->debugging = true;
+    }
+
+    /**
+     * Disable debugging. If debugging mode is enabled, the request will
+     * be included in the ApiException. By default, debugging is disabled to prevent
+     * sensitive request data from leaking into exception logs.
+     */
+    public function disableDebugging()
+    {
+        $this->debugging = false;
     }
 
     /**

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -28,6 +28,7 @@ use Mollie\Api\Endpoints\ShipmentEndpoint;
 use Mollie\Api\Endpoints\SubscriptionEndpoint;
 use Mollie\Api\Endpoints\WalletEndpoint;
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException;
 use Mollie\Api\Exceptions\IncompatiblePlatform;
 use Mollie\Api\HttpAdapter\MollieHttpAdapterPicker;
 
@@ -398,7 +399,47 @@ class MollieApiClient
     }
 
     /**
-     * Perform an http call. This method is used by the resource specific classes. Please use the $payments property to
+     * Enable debugging mode. If debugging mode is enabled, the attempted request will be included in the ApiException.
+     * By default, debugging is disabled to prevent leaking sensitive request data into exception logs.
+     *
+     * @throws \Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException
+     */
+    public function enableDebugging()
+    {
+        if (
+            ! method_exists($this->httpClient, 'supportsDebugging')
+            || ! $this->httpClient->supportsDebugging()
+        ) {
+            throw new HttpAdapterDoesNotSupportDebuggingException(
+                "Debugging is not supported by " . get_class($this->httpClient) . "."
+            );
+        }
+
+        $this->httpClient->enableDebugging();
+    }
+
+    /**
+     * Disable debugging mode. If debugging mode is enabled, the attempted request will be included in the ApiException.
+     * By default, debugging is disabled to prevent leaking sensitive request data into exception logs.
+     *
+     * @throws \Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException
+     */
+    public function disableDebugging()
+    {
+        if (
+            ! method_exists($this->httpClient, 'supportsDebugging')
+            || ! $this->httpClient->supportsDebugging()
+        ) {
+            throw new HttpAdapterDoesNotSupportDebuggingException(
+                "Debugging is not supported by " . get_class($this->httpClient) . "."
+            );
+        }
+
+        $this->httpClient->disableDebugging();
+    }
+
+    /**
+     * Perform a http call. This method is used by the resource specific classes. Please use the $payments property to
      * perform operations on payments.
      *
      * @param string $httpMethod
@@ -418,7 +459,7 @@ class MollieApiClient
     }
 
     /**
-     * Perform an http call to a full url. This method is used by the resource specific classes.
+     * Perform a http call to a full url. This method is used by the resource specific classes.
      *
      * @see $payments
      * @see $isuers

--- a/tests/Mollie/API/HttpAdapter/Guzzle6And7MollieHttpAdapterTest.php
+++ b/tests/Mollie/API/HttpAdapter/Guzzle6And7MollieHttpAdapterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Mollie\API\HttpAdapter;
+
+use Eloquent\Liberator\Liberator;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\HttpAdapter\Guzzle6And7MollieHttpAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class Guzzle6And7MollieHttpAdapterTest extends TestCase
+{
+    /** @test */
+    public function testDebuggingIsSupported()
+    {
+        $adapter = Guzzle6And7MollieHttpAdapter::createDefault();
+        $this->assertTrue($adapter->supportsDebugging());
+        $this->assertFalse($adapter->debugging());
+
+        $adapter->enableDebugging();
+        $this->assertTrue($adapter->debugging());
+
+        $adapter->disableDebugging();
+        $this->assertFalse($adapter->debugging());
+    }
+
+    /** @test */
+    public function whenDebuggingAnApiExceptionIncludesTheRequest()
+    {
+        $guzzleClient = $this->createMock(Client::class);
+        $guzzleClient
+        ->expects($this->once())
+        ->method('send')
+        ->with($this->isInstanceOf(Request::class))
+        ->willThrowException(
+            new ConnectException(
+                'Mock exception',
+                new Request('POST', 'https://api.mollie.com')
+            )
+        );
+
+        $adapter = new Guzzle6And7MollieHttpAdapter($guzzleClient);
+        $adapter->enableDebugging();
+
+        try {
+            $adapter->send(
+                'POST',
+                'https://api.mollie.com/v2/profiles/pfl_v9hTwCvYqw/methods/bancontact',
+                [],
+                /** @lang JSON */
+                '{ "foo": "bar" }'
+            );
+        } catch (ApiException $e) {
+            $exception = Liberator::liberate($e);
+            $this->assertInstanceOf(RequestInterface::class, $exception->request);
+        }
+    }
+
+    /** @test */
+    public function whenNotDebuggingAnApiExceptionIsExcludedFromTheRequest()
+    {
+        $guzzleClient = $this->createMock(Client::class);
+        $guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(Request::class))
+            ->willThrowException(
+                new ConnectException(
+                    'Mock exception',
+                    new Request('POST', 'https://api.mollie.com')
+                )
+            );
+
+        $adapter = new Guzzle6And7MollieHttpAdapter($guzzleClient);
+        $this->assertFalse($adapter->debugging());
+
+        try {
+            $adapter->send(
+                'POST',
+                'https://api.mollie.com/v2/profiles/pfl_v9hTwCvYqw/methods/bancontact',
+                [],
+                /** @lang JSON */
+                '{ "foo": "bar" }'
+            );
+        } catch (ApiException $e) {
+            $exception = Liberator::liberate($e);
+            $this->assertNull($exception->request);
+        }
+    }
+}

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Exceptions\HttpAdapterDoesNotSupportDebuggingException;
+use Mollie\Api\HttpAdapter\CurlMollieHttpAdapter;
 use Mollie\Api\HttpAdapter\Guzzle6And7MollieHttpAdapter;
 use Mollie\Api\MollieApiClient;
 
@@ -156,5 +158,21 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
             (object)['resource' => 'payment'],
             $parsedResponse
         );
+    }
+
+    public function testEnablingDebuggingThrowsAnExceptionIfHttpAdapterDoesNotSupportIt()
+    {
+        $this->expectException(HttpAdapterDoesNotSupportDebuggingException::class);
+        $client = new MollieApiClient(new CurlMollieHttpAdapter);
+
+        $client->enableDebugging();
+    }
+
+    public function testDisablingDebuggingThrowsAnExceptionIfHttpAdapterDoesNotSupportIt()
+    {
+        $this->expectException(HttpAdapterDoesNotSupportDebuggingException::class);
+        $client = new MollieApiClient(new CurlMollieHttpAdapter);
+
+        $client->disableDebugging();
     }
 }


### PR DESCRIPTION
This PR introduces a debugging mode to the client. This prevents accidentally leaking sensitive request data to exception logs when an `ApiException` gets thrown.

**Current behaviour**
Whenever possible, the request is stored on the `ApiException`. When logging the full exception instance, the request gets logged as well.

**New behaviour:**
By default, debugging is disabled and the request is not stored on any `ApiException`.
When debugging is enabled and whenever possible, the request is stored on the `ApiException`. When logging the full exception instance, the request gets logged as well.

Debugging can be enabled and disabled on the client:

```php
$mollie = new \Mollie\Api\MollieApiClient;
$mollie->enableDebugging();
$mollie->disableDebugging();
```

The actual debugging behaviour is tucked away in the http adapter.

This PR brings debugging to the included `Guzzle6And7MollieHttpAdapter` only - which is the adapter that is used most.

Note that the alternative `CurlMollieHttpAdapter` never was storing the request on any `ApiException`.