### PR TITLE
Revert curl retries

### DIFF
--- a/src/Exceptions/CurlConnectTimeoutException.php
+++ b/src/Exceptions/CurlConnectTimeoutException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Mollie\Api\Exceptions;
-
-class CurlConnectTimeoutException extends ApiException
-{
-}

--- a/src/HttpAdapter/CurlMollieHttpAdapter.php
+++ b/src/HttpAdapter/CurlMollieHttpAdapter.php
@@ -3,9 +3,7 @@
 namespace Mollie\Api\HttpAdapter;
 
 use Composer\CaBundle\CaBundle;
-use LogicException;
 use Mollie\Api\Exceptions\ApiException;
-use Mollie\Api\Exceptions\CurlConnectTimeoutException;
 use Mollie\Api\MollieApiClient;
 
 final class CurlMollieHttpAdapter implements MollieHttpAdapterInterface
@@ -26,61 +24,14 @@ final class CurlMollieHttpAdapter implements MollieHttpAdapterInterface
     const HTTP_NO_CONTENT = 204;
 
     /**
-     * The maximum number of retries
-     */
-    const MAX_RETRIES = 5;
-
-    /**
-     * The amount of milliseconds the delay is being increased with on each retry.
-     */
-    const DELAY_INCREASE_MS = 1000;
-
-    /**
-     * CurlMollieHttpAdapter constructor.
-     * @throws \LogicException
-     */
-    public function __construct()
-    {
-        if (self::DEFAULT_CONNECT_TIMEOUT >= self::DEFAULT_TIMEOUT) {
-            throw new LogicException("The connect timeout must be shorter than the response timeout.");
-        }
-    }
-
-    /**
      * @param string $httpMethod
      * @param string $url
      * @param array $headers
      * @param $httpBody
-     * @return \stdClass|void|null
+     * @return \stdClass|null
      * @throws \Mollie\Api\Exceptions\ApiException
-     * @throws \Mollie\Api\Exceptions\CurlConnectTimeoutException
      */
     public function send($httpMethod, $url, $headers, $httpBody)
-    {
-        for ($i = 0; $i <= self::MAX_RETRIES; $i++) {
-            usleep($i * self::DELAY_INCREASE_MS);
-
-            try {
-                return $this->attemptRequest($httpMethod, $url, $headers, $httpBody);
-            } catch (CurlConnectTimeoutException $e) {
-                // Nothing
-            }
-        }
-
-        throw new CurlConnectTimeoutException(
-            "Unable to connect to Mollie. Maximum number of retries (". self::MAX_RETRIES .") reached."
-        );
-    }
-
-    /**
-     * @param string $httpMethod
-     * @param string $url
-     * @param array $headers
-     * @param $httpBody
-     * @return \stdClass|void|null
-     * @throws \Mollie\Api\Exceptions\ApiException
-     */
-    protected function attemptRequest($httpMethod, $url, $headers, $httpBody)
     {
         $curl = curl_init($url);
         $headers["Content-Type"] = "application/json";
@@ -114,25 +65,15 @@ final class CurlMollieHttpAdapter implements MollieHttpAdapterInterface
                 throw new \InvalidArgumentException("Invalid http method: ". $httpMethod);
         }
 
-        $startTime = microtime(true);
         $response = curl_exec($curl);
-        $endTime = microtime(true);
 
         if ($response === false) {
-            $executionTime = $endTime - $startTime;
-            $curlErrorNumber = curl_errno($curl);
-            $curlErrorMessage = "Curl error: " . curl_error($curl);
-
-            if ($this->isConnectTimeoutError($curlErrorNumber, $executionTime)) {
-                throw new CurlConnectTimeoutException("Unable to connect to Mollie. " . $curlErrorMessage);
-            }
-
-            throw new ApiException($curlErrorMessage);
+            throw new ApiException("Curl error: " . curl_error($curl));
         }
 
-        curl_close($curl);
-
         $statusCode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+
+        curl_close($curl);
 
         return $this->parseResponseBody($response, $statusCode, $httpBody);
     }
@@ -146,46 +87,6 @@ final class CurlMollieHttpAdapter implements MollieHttpAdapterInterface
     public function versionString()
     {
         return 'Curl/*';
-    }
-
-    /**
-     * Whether this http adapter provides a debugging mode. If debugging mode is enabled, the
-     * request will be included in the ApiException.
-     *
-     * @return false
-     */
-    public function supportsDebugging()
-    {
-        return false;
-    }
-
-    /**
-     * @param $curlErrorNumber
-     * @param $executionTime
-     * @return bool
-     */
-    protected function isConnectTimeoutError($curlErrorNumber, $executionTime)
-    {
-        $connectErrors = [
-            \CURLE_COULDNT_RESOLVE_HOST => true,
-            \CURLE_COULDNT_CONNECT => true,
-            \CURLE_SSL_CONNECT_ERROR => true,
-            \CURLE_GOT_NOTHING => true,
-        ];
-
-        if (isset($connectErrors[$curlErrorNumber])) {
-            return true;
-        };
-
-        if ($curlErrorNumber === \CURLE_OPERATION_TIMEOUTED) {
-            if ($executionTime > self::DEFAULT_TIMEOUT) {
-                return false;
-            }
-
-            return true;
-        }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
There was an error reported about exceptions not being thrown correctly anymore since the curl retry feature was introduced. This PR reverts the introduction of the curl retry feature so we have a bit of time to figure it out.