### PR TITLE
Adding reason and reversedAt attributes to Chargeback resource

### DIFF
--- a/src/Resources/Chargeback.php
+++ b/src/Resources/Chargeback.php
@@ -54,6 +54,14 @@ class Chargeback extends BaseResource
     public $reason;
 
     /**
+     * UTC datetime the date and time the chargeback was reversed in ISO-8601 format.
+     *
+     * @example "2013-12-25T10:30:54+00:00"
+     * @var string|null
+     */
+    public $reversedAt;
+
+    /**
      * @var \stdClass
      */
     public $_links;

--- a/src/Resources/Chargeback.php
+++ b/src/Resources/Chargeback.php
@@ -49,7 +49,7 @@ class Chargeback extends BaseResource
     /**
      * The chargeback reason
      *
-     * @var \stdClass
+     * @var \stdClass|null
      */
     public $reason;
 

--- a/src/Resources/Chargeback.php
+++ b/src/Resources/Chargeback.php
@@ -47,6 +47,13 @@ class Chargeback extends BaseResource
     public $settlementAmount;
 
     /**
+     * The chargeback reason
+     *
+     * @var \stdClass
+     */
+    public $reason;
+
+    /**
      * @var \stdClass
      */
     public $_links;

--- a/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
@@ -74,10 +74,7 @@ class ChargebackEndpointTest extends BaseEndpointTest
                                "currency":"EUR"
                             },
                             "reversedAt": null,
-                            "reason":{
-                               "code":"AC04",
-                               "description":""
-                            },
+                            "reason": null,
                             "_links":{
                                "self":{
                                   "href":"https://api.mollie.com/v2/payments/tr_nQKWJbDj7j/chargebacks/chb_6cqlwf",
@@ -129,7 +126,7 @@ class ChargebackEndpointTest extends BaseEndpointTest
         );
 
         $this->assertChargeback($chargebacks[0], 'tr_44aKxzEbr8', 'chb_n9z0tp', "-13.00", "AC01");
-        $this->assertChargeback($chargebacks[1], 'tr_nQKWJbDj7j', 'chb_6cqlwf', "-0.37", "AC04");
+        $this->assertChargeback($chargebacks[1], 'tr_nQKWJbDj7j', 'chb_6cqlwf', "-0.37", null);
     }
 
     protected function assertChargeback($chargeback, $paymentId, $chargebackId, $amount, $reasonCode)
@@ -145,7 +142,11 @@ class ChargebackEndpointTest extends BaseEndpointTest
         $this->assertEquals($paymentId, $chargeback->paymentId);
         $this->assertNull($chargeback->reversedAt);
 
-        $this->assertReasonObject($reasonCode, "", $chargeback->reason);
+        if ($reasonCode === null) {
+            $this->assertNull($chargeback->reason);
+        } else {
+            $this->assertReasonObject($reasonCode, "", $chargeback->reason);
+        }
 
         $this->assertLinkObject(
             "https://api.mollie.com/v2/payments/{$paymentId}/chargebacks/{$chargebackId}",

--- a/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/ChargebackEndpointTest.php
@@ -40,6 +40,11 @@ class ChargebackEndpointTest extends BaseEndpointTest
                                "value":"-13.00",
                                "currency":"EUR"
                             },
+                            "reversedAt": null,
+                            "reason":{
+                               "code":"AC01",
+                               "description":""
+                            },
                             "_links":{
                                "self":{
                                   "href":"https://api.mollie.com/v2/payments/tr_44aKxzEbr8/chargebacks/chb_n9z0tp",
@@ -67,6 +72,11 @@ class ChargebackEndpointTest extends BaseEndpointTest
                             "settlementAmount":{
                                "value":"-0.37",
                                "currency":"EUR"
+                            },
+                            "reversedAt": null,
+                            "reason":{
+                               "code":"AC04",
+                               "description":""
                             },
                             "_links":{
                                "self":{
@@ -118,11 +128,11 @@ class ChargebackEndpointTest extends BaseEndpointTest
             $chargebacks->_links->self
         );
 
-        $this->assertChargeback($chargebacks[0], 'tr_44aKxzEbr8', 'chb_n9z0tp', "-13.00");
-        $this->assertChargeback($chargebacks[1], 'tr_nQKWJbDj7j', 'chb_6cqlwf', "-0.37");
+        $this->assertChargeback($chargebacks[0], 'tr_44aKxzEbr8', 'chb_n9z0tp', "-13.00", "AC01");
+        $this->assertChargeback($chargebacks[1], 'tr_nQKWJbDj7j', 'chb_6cqlwf', "-0.37", "AC04");
     }
 
-    protected function assertChargeback($chargeback, $paymentId, $chargebackId, $amount)
+    protected function assertChargeback($chargeback, $paymentId, $chargebackId, $amount, $reasonCode)
     {
         $this->assertInstanceOf(Chargeback::class, $chargeback);
         $this->assertEquals("chargeback", $chargeback->resource);
@@ -133,6 +143,9 @@ class ChargebackEndpointTest extends BaseEndpointTest
 
         $this->assertEquals("2018-03-28T11:44:32+00:00", $chargeback->createdAt);
         $this->assertEquals($paymentId, $chargeback->paymentId);
+        $this->assertNull($chargeback->reversedAt);
+
+        $this->assertReasonObject($reasonCode, "", $chargeback->reason);
 
         $this->assertLinkObject(
             "https://api.mollie.com/v2/payments/{$paymentId}/chargebacks/{$chargebackId}",
@@ -151,5 +164,21 @@ class ChargebackEndpointTest extends BaseEndpointTest
             "text/html",
             $chargeback->_links->documentation
         );
+    }
+
+    protected function assertReasonObject($code, $description, $reasonObject)
+    {
+        $this->assertEquals(
+            $this->createReasonObject($code, $description),
+            $reasonObject
+        );
+    }
+
+    protected function createReasonObject($code, $description)
+    {
+        return (object) [
+            'code' => $code,
+            'description' => $description,
+        ];
     }
 }


### PR DESCRIPTION
Mollie has 2 additional attributes for its chargebacks endpoint, see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback for more info.

This will update the Chargeback resourse with the additional attributs.

For possible reason codes see https://help.mollie.com/hc/nl/articles/115000309865
