### PR TITLE
Complete documentation of Method status types

### DIFF
--- a/src/Resources/Method.php
+++ b/src/Resources/Method.php
@@ -59,6 +59,7 @@ class Method extends BaseResource
 
     /**
      * The activation status the method is in.
+     * If the method has status "null", this value will be returned as a null value, not as a string.
      *
      * @var string | null
      */

--- a/src/Resources/Method.php
+++ b/src/Resources/Method.php
@@ -60,7 +60,7 @@ class Method extends BaseResource
     /**
      * The activation status the method is in.
      *
-     * @var string
+     * @var string | null
      */
     public $status;
 


### PR DESCRIPTION
See API documentation: https://docs.mollie.com/reference/v2/methods-api/get-method

The documentation of the different values for the "status" field is a bit ambiguous as it states type is "string" and the value "null" is documented the same as all other statuses.
However, we received a response containing "status" => null.

In a strictly typed project this causes errors (which is how we discovered this).
This extra documentation should make it clear that this is a valid case.
