### PR TITLE
Bugfix: Add metadata property

### DIFF
--- a/src/Resources/Refund.php
+++ b/src/Resources/Refund.php
@@ -91,6 +91,11 @@ class Refund extends BaseResource
     public $routingReversal;
 
     /**
+     * @var \stdClass|null
+     */
+    public $metadata;
+
+    /**
      * Is this refund queued?
      *
      * @return bool


### PR DESCRIPTION
When creating a refund, we would receive this error in PHP 8.2:

```php
Deprecated Functionality: Creation of dynamic property Mollie\Api\Resources\Refund::$metadata 
```

This PR adds the property to the class, although I'm not 100% sure about the type hint. 