### PR TITLE
Bugfix: Add resource property

### DIFF
--- a/src/Resources/Issuer.php
+++ b/src/Resources/Issuer.php
@@ -12,6 +12,11 @@ class Issuer extends BaseResource
     public $id;
 
     /**
+     * @var string
+     */
+    public $resource;
+
+    /**
      * Name of the issuer.
      *
      * @var string


### PR DESCRIPTION
Basically the same as https://github.com/mollie/mollie-api-php/pull/665.

When loading the issuers, we would receive this error in PHP 8.2:

```
Deprecated: Creation of dynamic property Mollie\Api\Resources\Issuer::$resource is deprecated
```

This PR adds the property to the class.