### PR TITLE
Revert "Bugfix: Add resource property"

### DIFF
--- a/src/Resources/Issuer.php
+++ b/src/Resources/Issuer.php
@@ -12,11 +12,6 @@ class Issuer extends BaseResource
     public $id;
 
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Name of the issuer.
      *
      * @var string


### PR DESCRIPTION
Reverts mollie/mollie-api-php#670.

`$resource` attribute already defined on parent class.