### PR TITLE
Cleanup unneeded property overrides from Resource classes

### DIFF
--- a/src/Resources/Capture.php
+++ b/src/Resources/Capture.php
@@ -6,6 +6,7 @@ class Capture extends BaseResource
 {
     /**
      * Always 'capture' for this object
+     *
      * @var string
      */
     public $resource;

--- a/src/Resources/Customer.php
+++ b/src/Resources/Customer.php
@@ -7,11 +7,6 @@ use Mollie\Api\Exceptions\ApiException;
 class Customer extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the customer.
      *
      * @var string

--- a/src/Resources/Invoice.php
+++ b/src/Resources/Invoice.php
@@ -9,11 +9,6 @@ class Invoice extends BaseResource
     /**
      * @var string
      */
-    public $resource;
-
-    /**
-     * @var string
-     */
     public $id;
 
     /**

--- a/src/Resources/Mandate.php
+++ b/src/Resources/Mandate.php
@@ -10,11 +10,6 @@ class Mandate extends BaseResource
     /**
      * @var string
      */
-    public $resource;
-
-    /**
-     * @var string
-     */
     public $id;
 
     /**

--- a/src/Resources/Method.php
+++ b/src/Resources/Method.php
@@ -71,12 +71,6 @@ class Method extends BaseResource
     public $_links;
 
     /**
-     *
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Get the issuer value objects
      *
      * @return IssuerCollection

--- a/src/Resources/Onboarding.php
+++ b/src/Resources/Onboarding.php
@@ -9,11 +9,6 @@ class Onboarding extends BaseResource
     /**
      * @var string
      */
-    public $resource;
-
-    /**
-     * @var string
-     */
     public $name;
 
     /**

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -9,11 +9,6 @@ use Mollie\Api\Types\OrderStatus;
 class Order extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the order.
      *
      * @example ord_8wmqcHMN4U

--- a/src/Resources/Partner.php
+++ b/src/Resources/Partner.php
@@ -5,11 +5,6 @@ namespace Mollie\Api\Resources;
 class Partner extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Indicates the type of partner. Will be null if the currently authenticated organization is
      * not enrolled as a partner. Possible values: "oauth", "signuplink", "useragent".
      *

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -10,11 +10,6 @@ use Mollie\Api\Types\SequenceType;
 class Payment extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the payment (on the Mollie platform).
      *
      * @var string

--- a/src/Resources/PaymentLink.php
+++ b/src/Resources/PaymentLink.php
@@ -5,11 +5,6 @@ namespace Mollie\Api\Resources;
 class PaymentLink extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the payment link (on the Mollie platform).
      *
      * @var string

--- a/src/Resources/Permission.php
+++ b/src/Resources/Permission.php
@@ -6,11 +6,6 @@ class Permission extends BaseResource
 {
     /**
      * @var string
-     */
-    public $resource;
-
-    /**
-     * @var string
      * @example payments.read
      */
     public $id;

--- a/src/Resources/Profile.php
+++ b/src/Resources/Profile.php
@@ -11,11 +11,6 @@ class Profile extends BaseResource
     /**
      * @var string
      */
-    public $resource;
-
-    /**
-     * @var string
-     */
     public $id;
 
     /**

--- a/src/Resources/Refund.php
+++ b/src/Resources/Refund.php
@@ -8,11 +8,6 @@ use Mollie\Api\Types\RefundStatus;
 class Refund extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the payment method.
      *
      * @var string

--- a/src/Resources/Route.php
+++ b/src/Resources/Route.php
@@ -5,11 +5,6 @@ namespace Mollie\Api\Resources;
 class Route extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the payment method.
      *
      * @var string

--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -9,11 +9,6 @@ use Mollie\Api\Types\SettlementStatus;
 class Settlement extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * Id of the settlement.
      *
      * @var string

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -5,11 +5,6 @@ namespace Mollie\Api\Resources;
 class Shipment extends BaseResource
 {
     /**
-     * @var string
-     */
-    public $resource;
-
-    /**
      * The shipment’s unique identifier,
      *
      * @example shp_3wmsgCJN4U

--- a/src/Resources/Subscription.php
+++ b/src/Resources/Subscription.php
@@ -10,11 +10,6 @@ class Subscription extends BaseResource
     /**
      * @var string
      */
-    public $resource;
-
-    /**
-     * @var string
-     */
     public $id;
 
     /**


### PR DESCRIPTION
I've kept the resource properties in the classes that actually add a description.