### PR TITLE
Update PaymentLink.php add archived parameter

### DIFF
--- a/src/Resources/PaymentLink.php
+++ b/src/Resources/PaymentLink.php
@@ -49,6 +49,14 @@ class PaymentLink extends BaseResource
     public $paidAt;
 
     /**
+     * Whether the payment link is archived. Customers will not be able to complete
+     * payments on archived payment links.
+     *
+     * @var boolean
+     */
+    public $archived;
+    
+    /**
      * UTC datetime the payment link was updated in ISO-8601 format.
      *
      * @example "2013-12-25T10:30:54+00:00"


### PR DESCRIPTION
## Specifications

  - API Version: v2
  - Endpoint: get-payment-link

## Issue

The get-payment-link endpoint defines an `archived` field in the response, but the related class `vendor/mollie/mollie-api-php/src/Resources/PaymentLink.php` doesn't have the attribute.