### PR TITLE
Run CI tests on PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
     name: PHP - ${{ matrix.php }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
With a few RC's released and the final release coming up in november, it might be a good thing to start running tests on the new PHP.