### PR TITLE
Add constant for Klarna One method.

### DIFF
--- a/src/Types/PaymentMethod.php
+++ b/src/Types/PaymentMethod.php
@@ -79,11 +79,13 @@ class PaymentMethod
      */
     public const KBC = "kbc";
 
+    public const KLARNA_ONE = "klarna";
+
     /**
      * @link https://www.mollie.com/en/payments/klarna-pay-later
      */
     public const KLARNA_PAY_LATER = "klarnapaylater";
-    
+
     /**
      * @link https://www.mollie.com/en/payments/klarna-pay-now
      */
@@ -124,7 +126,7 @@ class PaymentMethod
      * @link https://www.mollie.com/en/payments/sofort
      */
     public const SOFORT = "sofort";
-    
+
     /**
      * @link https://www.mollie.com/en/payments/in3
      */


### PR DESCRIPTION
Add a constant for the new Klarna one method that's used to provide Klarna in the UK.

Wasn't able to add a link as I don't think you have a public URL for the method yet as its still in beta.