### PR TITLE
NTR: Update return.php to include sync poll from API

### DIFF
--- a/examples/payments/return.php
+++ b/examples/payments/return.php
@@ -15,6 +15,19 @@ require_once "../functions.php";
 $status = database_read($_GET["order_id"]);
 
 /*
+ * The order status is normally updated by the webhook.
+ * In case the webhook did not yet arrive, we can poll the API synchronously.
+ */
+
+if ($status !== "paid") {
+    $payment = $mollie->payments->get($_GET["order_id"]);
+    $status = $payment->status;
+    /*
+     * Optionally, update the database here, or wait for the webhook to arrive.
+     */
+}
+
+/*
  * Determine the url parts to these example files.
  */
 $protocol = isset($_SERVER['HTTPS']) && strcasecmp('off', $_SERVER['HTTPS']) !== 0 ? "https" : "http";


### PR DESCRIPTION
We should make it a bit more clear that it is a possibility that the webhook has not yet arrived when the consumer returns.

See point 6 here: https://docs.mollie.com/payments/accepting-payments#working-with-the-payments-api
