### PR TITLE
fix: add preset options when updating payment

### DIFF
--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -729,7 +729,10 @@ class Payment extends BaseResource
             "dueDate" => $this->dueDate,
         ];
 
-        $result = $this->client->payments->update($this->id, $body);
+        $result = $this->client->payments->update(
+            $this->id,
+            $this->withPresetOptions($body)
+        );
 
         return ResourceFactory::createFromApiResult($result, new Payment($this->client));
     }


### PR DESCRIPTION
Now, when updating a payment it doesn't merge the preset options. This causes it to fail when using oauth with testmode.