### PR TITLE
Add new Payment address fields

### DIFF
--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -80,7 +80,7 @@ class Order extends BaseResource
     public $orderNumber;
 
     /**
-     * The person and the address the order is billed to.
+     * The person and the address the order is shipped to.
      *
      * @var \stdClass
      */

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -144,6 +144,7 @@ class Payment extends BaseResource
      *
      * @example "user@mollie.com"
      * @var string|null
+     * @deprecated 2024-06-01 The billingEmail field is deprecated. Use the "billingAddress" field instead.
      */
     public $billingEmail;
 

--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -208,6 +208,20 @@ class Payment extends BaseResource
     public $orderId;
 
     /**
+     * The person and the address the order is billed to.
+     *
+     * @var \stdClass|null
+     */
+    public $billingAddress;
+
+    /**
+     * The person and the address the order is shipped to.
+     *
+     * @var \stdClass|null
+     */
+    public $shippingAddress;
+
+    /**
      * The settlement ID this payment belongs to.
      *
      * @example stl_jDk30akdN


### PR DESCRIPTION
This PR adds the `shippingAddress` and `billingAddress` fields to the Payment resource.

Additionally, the `Payment.billingEmail` is marked for deprecation.