### PR TITLE
Correct migration link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The easiest way to install the Mollie API client is by using [Composer](http://g
 composer require mollie/mollie-api-php
 ```
 
-To work with the most recent API version, ensure that you are using a version of this API client that is equal to or greater than 2.0.0. If you prefer to continue using the v1 API, make sure your client version is below 2.0.0. For guidance on transitioning from v1 to v2, please refer to the [migration notes](https://docs.mollie.com/migrating-v1-to-v2).
+To work with the most recent API version, ensure that you are using a version of this API client that is equal to or greater than 2.0.0. If you prefer to continue using the v1 API, make sure your client version is below 2.0.0. For guidance on transitioning from v1 to v2, please refer to the [migration notes](https://docs.mollie.com/docs/migrating-from-v1-to-v2).
 
 ### Manual Installation ###
 If you're not familiar with using composer we've added a ZIP file to the releases containing the API client and all the packages normally installed by composer.


### PR DESCRIPTION
We are currently working on moving our legacy customers over from V1 to V2 of the API and in the process noticed that the link to the documentation is incorrect. I have created a pull request that corrects the link to the correct one.

Have a nice day!