### PR TITLE
NTR: Add Trustly enum

### DIFF
--- a/src/Types/PaymentMethod.php
+++ b/src/Types/PaymentMethod.php
@@ -70,7 +70,7 @@ class PaymentMethod
     public const GIFTCARD = "giftcard";
 
     /**
-     * @deprecated 
+     * @deprecated
      * @link https://www.mollie.com/en/payments/giropay
      */
     public const GIROPAY = "giropay";

--- a/src/Types/PaymentMethod.php
+++ b/src/Types/PaymentMethod.php
@@ -70,6 +70,7 @@ class PaymentMethod
     public const GIFTCARD = "giftcard";
 
     /**
+     * @deprecated 
      * @link https://www.mollie.com/en/payments/giropay
      */
     public const GIROPAY = "giropay";
@@ -156,6 +157,11 @@ class PaymentMethod
      * @link https://www.mollie.com/en/payments/riverty
      */
     public const RIVERTY = "riverty";
+
+    /**
+     * @link https://www.mollie.com/en/payments/trustly
+     */
+    public const TRUSTLY = "trustly";
 
     /**
      * @link https://www.mollie.com/en/payments/twint


### PR DESCRIPTION
And mark `giropay` as deprecated

Fixes #730
