### PR TITLE
Enhanced methods.allActive() for integration consistency and added methods.list()

### DIFF
--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -6,6 +6,7 @@ use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Method;
 use Mollie\Api\Resources\MethodCollection;
 use Mollie\Api\Resources\ResourceFactory;
+use Mollie\Api\Types\PaymentMethodStatus;
 
 class MethodEndpoint extends CollectionEndpointAbstract
 {
@@ -44,7 +45,22 @@ class MethodEndpoint extends CollectionEndpointAbstract
      */
     public function allActive(array $parameters = [])
     {
-        return parent::rest_list(null, null, $parameters);
+        $url = 'methods/all' . $this->buildQueryString($parameters);
+
+        $result = $this->client->performHttpCall('GET', $url);
+
+        $data = array_filter($result->_embedded->methods, function ($method) {
+            return $method->status === PaymentMethodStatus::ACTIVATED;
+        });
+
+        unset($result->_links->self); // Remove incorrect self link
+
+        return ResourceFactory::createBaseResourceCollection(
+            $this->client,
+            Method::class,
+            $data,
+            $result->_links
+        );
     }
 
     /**

--- a/src/Endpoints/MethodEndpoint.php
+++ b/src/Endpoints/MethodEndpoint.php
@@ -116,4 +116,18 @@ class MethodEndpoint extends CollectionEndpointAbstract
 
         return parent::rest_read($methodId, $parameters);
     }
+
+    /**
+     * Retrieve a complete, non-paginated collection of active Mollie payment methods.
+     * Note that only Euro supporting methods are included.
+     * For a full list of activated methods regardless the currency use the allActive() method.
+     *
+     * @param array $parameters
+     * @return mixed|\Mollie\Api\Resources\BaseCollection
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function list(array $parameters = [])
+    {
+        return $this->rest_list(null, null, $parameters);
+    }
 }

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -522,6 +522,20 @@ class MollieApiClient
     }
 
     /**
+     * Returns true if the API key is a test key. Returns false if Oauth is used.
+     *
+     * @return bool
+     */
+    public function usesTestmodeApiKey()
+    {
+        if ($this->usesOAuth()) {
+            return false;
+        }
+
+        return strpos($this->apiKey, 'test_') === 0;
+    }
+
+    /**
      * @param string $versionString
      *
      * @return MollieApiClient

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -269,29 +269,30 @@ class MethodEndpointTest extends BaseEndpointTest
     public function testGetTranslatedMethod()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods/sofort?locale=de_DE'),
+            new Request('GET', '/v2/methods/creditcard?locale=de_DE'),
             new Response(
                 200,
                 [],
                 '{
                     "resource": "method",
-                    "id": "sofort",
-                    "description": "SOFORT \u00dcberweisung",
+                    "id": "creditcard",
+                    "description": "Karte",
                     "minimumAmount": {
                         "value": "0.01",
                         "currency": "EUR"
                     },
                     "maximumAmount": {
-                        "value": "50000.00",
+                        "value": "10000.00",
                         "currency": "EUR"
                     },
                     "image": {
-                        "size1x": "https://www.mollie.com/images/payscreen/methods/sofort.png",
-                        "size2x": "https://www.mollie.com/images/payscreen/methods/sofort%402x.png"
+                        "size1x": "https://www.mollie.com/external/icons/payment-methods/creditcard.png",
+                        "size2x": "https://www.mollie.com/external/icons/payment-methods/creditcard%402x.png",
+                        "svg": "https://www.mollie.com/external/icons/payment-methods/creditcard.svg"
                     },
                     "_links": {
                         "self": {
-                            "href": "https://api.mollie.com/v2/methods/sofort",
+                            "href": "https://api.mollie.com/v2/methods/creditcard",
                             "type": "application/hal+json"
                         },
                         "documentation": {
@@ -303,16 +304,16 @@ class MethodEndpointTest extends BaseEndpointTest
             )
         );
 
-        $method = $this->apiClient->methods->get('sofort', ['locale' => 'de_DE']);
+        $method = $this->apiClient->methods->get('creditcard', ['locale' => 'de_DE']);
 
         $this->assertInstanceOf(Method::class, $method);
-        $this->assertEquals('sofort', $method->id);
-        $this->assertEquals('SOFORT Überweisung', $method->description);
+        $this->assertEquals('creditcard', $method->id);
+        $this->assertEquals('Karte', $method->description);
         $this->assertAmountObject(0.01, 'EUR', $method->minimumAmount);
-        $this->assertAmountObject(50000, 'EUR', $method->maximumAmount);
+        $this->assertAmountObject(10000, 'EUR', $method->maximumAmount);
 
         $this->assertLinkObject(
-            'https://api.mollie.com/v2/methods/sofort',
+            'https://api.mollie.com/v2/methods/creditcard',
             'application/hal+json',
             $method->_links->self
         );

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -312,28 +312,23 @@ class MethodEndpointTest extends BaseEndpointTest
         $this->assertAmountObject(0.01, 'EUR', $method->minimumAmount);
         $this->assertAmountObject(50000, 'EUR', $method->maximumAmount);
 
-        $amount = new Stdclass();
-        $amount->size1x = 'https://www.mollie.com/images/payscreen/methods/sofort.png';
-        $amount->size2x = 'https://www.mollie.com/images/payscreen/methods/sofort%402x.png';
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/methods/sofort',
+            'application/hal+json',
+            $method->_links->self
+        );
 
-        $selfLink = (object)[
-            'href' => 'https://api.mollie.com/v2/methods/sofort',
-            'type' => 'application/hal+json',
-        ];
-        $this->assertEquals($selfLink, $method->_links->self);
-
-        $documentationLink = (object)[
-            'href' => 'https://docs.mollie.com/reference/v2/methods-api/get-method',
-            'type' => 'text/html',
-        ];
-
-        $this->assertEquals($documentationLink, $method->_links->documentation);
+        $this->assertLinkObject(
+            'https://docs.mollie.com/reference/v2/methods-api/get-method',
+            'text/html',
+            $method->_links->documentation
+        );
     }
 
     public function testListAllActiveMethods()
     {
         $this->mockApiCall(
-            new Request('GET', '/v2/methods'),
+            new Request('GET', '/v2/methods/all'),
             new Response(
                 200,
                 [],
@@ -356,6 +351,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/ideal",
@@ -379,6 +375,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/creditcard",
@@ -402,6 +399,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/mistercash",
@@ -422,6 +420,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
                                 },
+                                "status": "rejected",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/giftcard",
@@ -449,8 +448,8 @@ class MethodEndpointTest extends BaseEndpointTest
         $methods = $this->apiClient->methods->allActive();
 
         $this->assertInstanceOf(MethodCollection::class, $methods);
-        $this->assertEquals(4, $methods->count);
-        $this->assertCount(4, $methods);
+        $this->assertEquals(3, $methods->count);
+        $this->assertCount(3, $methods);
 
         $documentationLink = (object)[
             'href' => 'https://docs.mollie.com/reference/v2/methods-api/list-methods',
@@ -458,11 +457,7 @@ class MethodEndpointTest extends BaseEndpointTest
         ];
         $this->assertEquals($documentationLink, $methods->_links->documentation);
 
-        $selfLink = (object)[
-            'href' => 'http://api.mollie.com/v2/methods',
-            'type' => 'application/hal+json',
-        ];
-        $this->assertEquals($selfLink, $methods->_links->self);
+        $this->assertFalse(isset($methods->_links->self));
 
         $creditcardMethod = $methods[1];
 
@@ -474,11 +469,11 @@ class MethodEndpointTest extends BaseEndpointTest
         $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
         $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
 
-        $selfLink = (object)[
-            'href' => 'https://api.mollie.com/v2/methods/creditcard',
-            'type' => 'application/hal+json',
-        ];
-        $this->assertEquals($selfLink, $creditcardMethod->_links->self);
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/methods/creditcard',
+            'application/hal+json',
+            $creditcardMethod->_links->self
+        );
     }
 
     public function testListAllAvailableMethods()

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -41,6 +41,7 @@ class MethodEndpointTest extends BaseEndpointTest
                         "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
                         "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
                     },
+                    "status": "activated",
                     "_links": {
                         "self": {
                             "href": "https://api.mollie.com/v2/methods/ideal",
@@ -113,7 +114,7 @@ class MethodEndpointTest extends BaseEndpointTest
                             }
                         }
                     ],
-
+                    "status": "activated",
                     "_links": {
                         "self": {
                             "href": "https://api.mollie.com/v2/methods/ideal",
@@ -202,6 +203,7 @@ class MethodEndpointTest extends BaseEndpointTest
                              "variable": "0"
                          }
                      ],
+                     "status": "activated",
                      "_links": {
                          "self": {
                              "href": "https://api.mollie.com/v2/methods/ideal",
@@ -290,6 +292,7 @@ class MethodEndpointTest extends BaseEndpointTest
                         "size2x": "https://www.mollie.com/external/icons/payment-methods/creditcard%402x.png",
                         "svg": "https://www.mollie.com/external/icons/payment-methods/creditcard.svg"
                     },
+                    "status": "activated",
                     "_links": {
                         "self": {
                             "href": "https://api.mollie.com/v2/methods/creditcard",
@@ -508,6 +511,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                         "variable": "0"
                                     }
                                 ],
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/ideal",
@@ -531,6 +535,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/creditcard",
@@ -554,6 +559,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
                                 },
+                                "status": "rejected",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/mistercash",
@@ -574,6 +580,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
                                 },
+                                "status": "pending",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/giftcard",
@@ -655,6 +662,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "value": "50000.00",
                                     "currency": "EUR"
                                 },
+                                "status": "activated",
                                 "image": {
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
@@ -682,6 +690,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/creditcard",
@@ -705,6 +714,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/mistercash",
@@ -725,6 +735,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
                                 },
+                                "status": "activated",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/giftcard",

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -10,7 +10,6 @@ use Mollie\Api\Resources\Method;
 use Mollie\Api\Resources\MethodCollection;
 use Mollie\Api\Resources\MethodPrice;
 use Mollie\Api\Resources\MethodPriceCollection;
-use stdClass;
 use Tests\Mollie\TestHelpers\AmountObjectTestHelpers;
 use Tests\Mollie\TestHelpers\LinkObjectTestHelpers;
 
@@ -450,17 +449,14 @@ class MethodEndpointTest extends BaseEndpointTest
         $this->assertInstanceOf(MethodCollection::class, $methods);
         $this->assertEquals(3, $methods->count);
         $this->assertCount(3, $methods);
-
-        $documentationLink = (object)[
-            'href' => 'https://docs.mollie.com/reference/v2/methods-api/list-methods',
-            'type' => 'text/html',
-        ];
-        $this->assertEquals($documentationLink, $methods->_links->documentation);
-
+        $this->assertLinkObject(
+            'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+            'text/html',
+            $methods->_links->documentation
+        );
         $this->assertFalse(isset($methods->_links->self));
 
         $creditcardMethod = $methods[1];
-
         $this->assertInstanceOf(Method::class, $creditcardMethod);
         $this->assertEquals('creditcard', $creditcardMethod->id);
         $this->assertEquals('Credit card', $creditcardMethod->description);
@@ -468,7 +464,6 @@ class MethodEndpointTest extends BaseEndpointTest
         $this->assertAmountObject(2000, 'EUR', $creditcardMethod->maximumAmount);
         $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
         $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
-
         $this->assertLinkObject(
             'https://api.mollie.com/v2/methods/creditcard',
             'application/hal+json',
@@ -635,5 +630,161 @@ class MethodEndpointTest extends BaseEndpointTest
             'application/hal+json',
             $creditcardMethod->_links->self
         );
+    }
+
+    public function testListMethods()
+    {
+        $this->mockApiCall(
+            new Request('GET', '/v2/methods'),
+            new Response(
+                200,
+                [],
+                '{
+                    "_embedded": {
+                        "methods": [
+                            {
+                                "resource": "method",
+                                "id": "ideal",
+                                "description": "iDEAL",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/ideal",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "creditcard",
+                                "description": "Credit card",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "2000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/creditcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "mistercash",
+                                "description": "Bancontact",
+                                "minimumAmount": {
+                                    "value": "0.02",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/mistercash",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "giftcard",
+                                "description": "Gift cards",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": null,
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
+                                },
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/giftcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "count": 4,
+                    "_links": {
+                        "documentation": {
+                            "href": "https://docs.mollie.com/reference/v2/methods-api/list-methods",
+                            "type": "text/html"
+                        },
+                        "self": {
+                            "href": "http://api.mollie.com/v2/methods",
+                            "type": "application/hal+json"
+                        }
+                    }
+                }'
+            )
+        );
+
+        $methods = $this->apiClient->methods->list();
+
+        $this->assertInstanceOf(MethodCollection::class, $methods);
+        $this->assertEquals(4, $methods->count);
+        $this->assertCount(4, $methods);
+
+        $this->assertLinkObject(
+            'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+            'text/html',
+            $methods->_links->documentation
+        );
+
+        $selfLink = (object)[
+            'href' => 'http://api.mollie.com/v2/methods',
+            'type' => 'application/hal+json',
+        ];
+        $this->assertEquals($selfLink, $methods->_links->self);
+        $this->assertLinkObject(
+            'http://api.mollie.com/v2/methods',
+            'application/hal+json',
+            $methods->_links->self
+        );
+
+        $creditcardMethod = $methods[1];
+
+        $this->assertInstanceOf(Method::class, $creditcardMethod);
+        $this->assertEquals('creditcard', $creditcardMethod->id);
+        $this->assertEquals('Credit card', $creditcardMethod->description);
+        $this->assertAmountObject(0.01, 'EUR', $creditcardMethod->minimumAmount);
+        $this->assertAmountObject(2000, 'EUR', $creditcardMethod->maximumAmount);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
+
+        $selfLink = (object)[
+            'href' => 'https://api.mollie.com/v2/methods/creditcard',
+            'type' => 'application/hal+json',
+        ];
+        $this->assertEquals($selfLink, $creditcardMethod->_links->self);
     }
 }

--- a/tests/Mollie/API/Endpoints/MethodEndpointTest.php
+++ b/tests/Mollie/API/Endpoints/MethodEndpointTest.php
@@ -328,7 +328,7 @@ class MethodEndpointTest extends BaseEndpointTest
         );
     }
 
-    public function testListAllActiveMethods()
+    public function testListAllActiveMethodsInLiveMode()
     {
         $this->mockApiCall(
             new Request('GET', '/v2/methods/all'),
@@ -423,7 +423,7 @@ class MethodEndpointTest extends BaseEndpointTest
                                     "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
                                     "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
                                 },
-                                "status": "rejected",
+                                "status": "pending",
                                 "_links": {
                                     "self": {
                                         "href": "https://api.mollie.com/v2/methods/giftcard",
@@ -473,6 +473,309 @@ class MethodEndpointTest extends BaseEndpointTest
             'application/hal+json',
             $creditcardMethod->_links->self
         );
+    }
+
+    public function testListAllActiveMethodsInTestModeWithApiKey()
+    {
+        $this->mockApiCall(
+            new Request('GET', '/v2/methods/all'),
+            new Response(
+                200,
+                [],
+                '{
+                    "_embedded": {
+                        "methods": [
+                            {
+                                "resource": "method",
+                                "id": "ideal",
+                                "description": "iDEAL",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/ideal",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "creditcard",
+                                "description": "Credit card",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "2000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/creditcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "mistercash",
+                                "description": "Bancontact",
+                                "minimumAmount": {
+                                    "value": "0.02",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/mistercash",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "giftcard",
+                                "description": "Gift cards",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": null,
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
+                                },
+                                "status": "pending-review",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/giftcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "count": 4,
+                    "_links": {
+                        "documentation": {
+                            "href": "https://docs.mollie.com/reference/v2/methods-api/list-methods",
+                            "type": "text/html"
+                        },
+                        "self": {
+                            "href": "http://api.mollie.com/v2/methods",
+                            "type": "application/hal+json"
+                        }
+                    }
+                }'
+            )
+        );
+
+        $methods = $this->apiClient->methods->allActive();
+
+        $this->assertInstanceOf(MethodCollection::class, $methods);
+        $this->assertEquals(4, $methods->count);
+        $this->assertCount(4, $methods);
+        $this->assertLinkObject(
+            'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+            'text/html',
+            $methods->_links->documentation
+        );
+        $this->assertFalse(isset($methods->_links->self));
+
+        $creditcardMethod = $methods[1];
+        $this->assertInstanceOf(Method::class, $creditcardMethod);
+        $this->assertEquals('creditcard', $creditcardMethod->id);
+        $this->assertEquals('Credit card', $creditcardMethod->description);
+        $this->assertAmountObject(0.01, 'EUR', $creditcardMethod->minimumAmount);
+        $this->assertAmountObject(2000, 'EUR', $creditcardMethod->maximumAmount);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/methods/creditcard',
+            'application/hal+json',
+            $creditcardMethod->_links->self
+        );
+
+        $pendingCardMethod = $methods[2];
+        $this->assertInstanceOf(Method::class, $pendingCardMethod);
+        $this->assertEquals('mistercash', $pendingCardMethod->id);
+    }
+
+    public function testListAllActiveMethodsInTestModeWithOauth()
+    {
+        $this->mockApiCall(
+            new Request('GET', '/v2/methods/all?testmode=true'),
+            new Response(
+                200,
+                [],
+                '{
+                    "_embedded": {
+                        "methods": [
+                            {
+                                "resource": "method",
+                                "id": "ideal",
+                                "description": "iDEAL",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/ideal",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "creditcard",
+                                "description": "Credit card",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "2000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/creditcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "mistercash",
+                                "description": "Bancontact",
+                                "minimumAmount": {
+                                    "value": "0.02",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": {
+                                    "value": "50000.00",
+                                    "currency": "EUR"
+                                },
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/mistercash.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/mistercash%402x.png"
+                                },
+                                "status": "activated",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/mistercash",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            },
+                            {
+                                "resource": "method",
+                                "id": "giftcard",
+                                "description": "Gift cards",
+                                "minimumAmount": {
+                                    "value": "0.01",
+                                    "currency": "EUR"
+                                },
+                                "maximumAmount": null,
+                                "image": {
+                                    "size1x": "https://www.mollie.com/images/payscreen/methods/giftcard.png",
+                                    "size2x": "https://www.mollie.com/images/payscreen/methods/giftcard%402x.png"
+                                },
+                                "status": "pending-review",
+                                "_links": {
+                                    "self": {
+                                        "href": "https://api.mollie.com/v2/methods/giftcard",
+                                        "type": "application/hal+json"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "count": 4,
+                    "_links": {
+                        "documentation": {
+                            "href": "https://docs.mollie.com/reference/v2/methods-api/list-methods",
+                            "type": "text/html"
+                        },
+                        "self": {
+                            "href": "http://api.mollie.com/v2/methods",
+                            "type": "application/hal+json"
+                        }
+                    }
+                }'
+            )
+        );
+
+        $this->apiClient->setAccessToken('access_foobarfoobarfoobarfoobar');
+        $methods = $this->apiClient->methods->allActive(['testmode' => true]);
+
+        $this->assertInstanceOf(MethodCollection::class, $methods);
+        $this->assertEquals(4, $methods->count);
+        $this->assertCount(4, $methods);
+        $this->assertLinkObject(
+            'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+            'text/html',
+            $methods->_links->documentation
+        );
+        $this->assertFalse(isset($methods->_links->self));
+
+        $creditcardMethod = $methods[1];
+        $this->assertInstanceOf(Method::class, $creditcardMethod);
+        $this->assertEquals('creditcard', $creditcardMethod->id);
+        $this->assertEquals('Credit card', $creditcardMethod->description);
+        $this->assertAmountObject(0.01, 'EUR', $creditcardMethod->minimumAmount);
+        $this->assertAmountObject(2000, 'EUR', $creditcardMethod->maximumAmount);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard.png', $creditcardMethod->image->size1x);
+        $this->assertEquals('https://www.mollie.com/images/payscreen/methods/creditcard%402x.png', $creditcardMethod->image->size2x);
+        $this->assertLinkObject(
+            'https://api.mollie.com/v2/methods/creditcard',
+            'application/hal+json',
+            $creditcardMethod->_links->self
+        );
+
+        $pendingCardMethod = $methods[2];
+        $this->assertInstanceOf(Method::class, $pendingCardMethod);
+        $this->assertEquals('mistercash', $pendingCardMethod->id);
     }
 
     public function testListAllAvailableMethods()

--- a/tests/Mollie/API/MollieApiClientTest.php
+++ b/tests/Mollie/API/MollieApiClientTest.php
@@ -298,6 +298,22 @@ class MollieApiClientTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($mollieClient->getIdempotencyKey());
     }
 
+    /** @test */
+    public function testUsesTestmodeApiKeyWorks()
+    {
+        $mollieClient = new MollieApiClient;
+        $this->assertFalse($mollieClient->usesTestmodeApiKey());
+
+        $mollieClient->setAccessToken('access_foobarfoobarfoobarfoobarfoobar');
+        $this->assertFalse($mollieClient->usesTestmodeApiKey());
+
+        $mollieClient->setApiKey('live_foobarfoobarfoobarfoobarfoobar');
+        $this->assertFalse($mollieClient->usesTestmodeApiKey());
+
+        $mollieClient->setApiKey('test_foobarfoobarfoobarfoobarfoobar');
+        $this->assertTrue($mollieClient->usesTestmodeApiKey());
+    }
+
     /**
      * @param $httpMethod
      * @return void


### PR DESCRIPTION
This PR ensures integration consistency: `methods.allActive()` now returns the full set of activated methods regardless the currencies supported.

Context: Mollie added support for `twint` recently, which does not appear on `/v2/methods` by default because Twint does not support the `EUR` currency.

To mirror the API, the `list()` method is added for directly interacting with `v2/methods`.

```php
$mollie->methods->list(); // Directly interact with the "/v2/methods" endpoint
$mollie->methods->allActive(); // Enhanced for consistency: returns all methods regardless the currencies supported
```