### PR TITLE
Endpoint structure change poc

### DIFF
--- a/src/Contracts/HasBody.php
+++ b/src/Contracts/HasBody.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Contracts;
+
+interface HasBody
+{
+    /**
+     * Get the body of the response.
+     *
+     * @return string
+     */
+    public function getBody(): string;
+}

--- a/src/Contracts/IsIteratable.php
+++ b/src/Contracts/IsIteratable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Mollie\Api\Contracts;
+
+interface IsIteratable
+{
+    public function iteratorEnabled(): bool;
+
+    public function iteratesBackwards(): bool;
+}

--- a/src/Http/BaseEndpointCollection.php
+++ b/src/Http/BaseEndpointCollection.php
@@ -74,27 +74,6 @@ abstract class BaseEndpointCollection
     }
 
     /**
-     * Create a generator for iterating over a resource's collection using REST API calls.
-     *
-     * This function fetches paginated data from a RESTful resource endpoint and returns a generator
-     * that allows you to iterate through the items in the collection one by one. It supports forward
-     * and backward iteration, pagination, and filtering.
-     *
-     * @param string $from The first resource ID you want to include in your list.
-     * @param int $limit
-     * @param array $filters
-     * @param bool $iterateBackwards Set to true for reverse order iteration (default is false).
-     * @return LazyCollection
-     */
-    protected function createIterator(?string $from = null, ?int $limit = null, array $filters = [], bool $iterateBackwards = false): LazyCollection
-    {
-        /** @var CursorCollection $page */
-        $page = $this->fetchCollection($from, $limit, $filters);
-
-        return $page->getAutoIterator($iterateBackwards);
-    }
-
-    /**
      * @param array $filters
      * @return string
      */

--- a/src/Http/BaseEndpointCollection.php
+++ b/src/Http/BaseEndpointCollection.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Mollie\Api\Http;
+
+use Mollie\Api\Contracts\HasBody;
+use Mollie\Api\Http\Request;
+use Mollie\Api\Contracts\IsIteratable;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\BaseCollection;
+use Mollie\Api\Resources\BaseResource;
+use Mollie\Api\Resources\CursorCollection;
+use Mollie\Api\Resources\ResourceFactory;
+
+abstract class BaseEndpointCollection
+{
+    /**
+     * @var MollieApiClient
+     */
+    protected MollieApiClient $client;
+
+    public function __construct(MollieApiClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function send(Request $request): mixed
+    {
+        $path = $request->resolveResourcePath()
+            . $this->buildQueryString($request->getQuery());
+
+        $body = $request instanceof HasBody
+            ? $request->getBody()
+            : null;
+
+        $result = $this->client->performHttpCall(
+            $request->getMethod(),
+            $path,
+            $body
+        );
+
+        if ($result->isEmpty()) {
+            return null;
+        }
+
+        $targetResourceClass = $request->getTargetResourceClass();
+
+        if (is_subclass_of($targetResourceClass, BaseCollection::class)) {
+            $collection = $this->buildResultCollection($result->decode(), $targetResourceClass);
+
+            if ($request instanceof IsIteratable && $request->iteratorEnabled()) {
+                /** @var CursorCollection $collection */
+                return $collection->getAutoIterator($request->iteratesBackwards());
+            }
+
+            return $collection;
+        }
+
+        if (is_subclass_of($targetResourceClass, BaseResource::class)) {
+            return ResourceFactory::createFromApiResult($this->client, $result->decode(), $targetResourceClass);
+        }
+
+        return null;
+    }
+
+    protected function buildResultCollection(object $result, string $targetCollectionClass): BaseCollection
+    {
+        return ResourceFactory::createBaseResourceCollection(
+            $this->client,
+            ($targetCollectionClass)::getResourceClass(),
+            $result->_embedded->{$targetCollectionClass::getCollectionResourceName()},
+            $result->_links,
+            $targetCollectionClass
+        );
+    }
+
+    /**
+     * Create a generator for iterating over a resource's collection using REST API calls.
+     *
+     * This function fetches paginated data from a RESTful resource endpoint and returns a generator
+     * that allows you to iterate through the items in the collection one by one. It supports forward
+     * and backward iteration, pagination, and filtering.
+     *
+     * @param string $from The first resource ID you want to include in your list.
+     * @param int $limit
+     * @param array $filters
+     * @param bool $iterateBackwards Set to true for reverse order iteration (default is false).
+     * @return LazyCollection
+     */
+    protected function createIterator(?string $from = null, ?int $limit = null, array $filters = [], bool $iterateBackwards = false): LazyCollection
+    {
+        /** @var CursorCollection $page */
+        $page = $this->fetchCollection($from, $limit, $filters);
+
+        return $page->getAutoIterator($iterateBackwards);
+    }
+
+    /**
+     * @param array $filters
+     * @return string
+     */
+    protected function buildQueryString(array $filters): string
+    {
+        if (empty($filters)) {
+            return "";
+        }
+
+        foreach ($filters as $key => $value) {
+            if ($value === true) {
+                $filters[$key] = "true";
+            }
+
+            if ($value === false) {
+                $filters[$key] = "false";
+            }
+        }
+
+        return "?" . http_build_query($filters, "", "&");
+    }
+}

--- a/src/Http/EndpointCollection/BalanceEndpointCollection.php
+++ b/src/Http/EndpointCollection/BalanceEndpointCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mollie\Api\Http\EndpointCollection;
+
+use Mollie\Api\Http\BaseEndpointCollection;
+use Mollie\Api\Http\Requests\GetPaginatedBalancesRequest;
+use Mollie\Api\Resources\BalanceCollection;
+
+class BalanceEndpointCollection extends BaseEndpointCollection
+{
+    /**
+     * Get the balance endpoint.
+     *
+     * @return BalanceEndpoint
+     */
+    public function page(?string $from = null, ?int $limit = null, array $parameters = []): BalanceCollection
+    {
+        return $this->send(new GetPaginatedBalancesRequest($from, $limit, $parameters));
+    }
+}

--- a/src/Http/EndpointCollection/PaymentEndpointCollection.php
+++ b/src/Http/EndpointCollection/PaymentEndpointCollection.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Mollie\Api\Http\EndpointCollection;
+
+use Mollie\Api\Http\BaseEndpointCollection;
+use Mollie\Api\Http\Requests\GetPaginatedPaymentsRequest;
+use Mollie\Api\Http\Requests\GetPaymentRequest;
+use Mollie\Api\Http\Requests\RefundPaymentRequest;
+use Mollie\Api\Resources\LazyCollection;
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Resources\PaymentCollection;
+use Mollie\Api\Resources\Refund;
+
+class PaymentEndpointCollection extends BaseEndpointCollection
+{
+    /**
+     * Get the balance endpoint.
+     *
+     * @return PaymentCollection
+     */
+    public function page(?string $from = null, ?int $limit = null, array $filters = []): PaymentCollection
+    {
+        return $this->send(new GetPaginatedPaymentsRequest($from, $limit, $filters));
+    }
+
+    /**
+     * Retrieve a single payment from Mollie.
+     *
+     * Will throw a ApiException if the payment id is invalid or the resource cannot be found.
+     *
+     * @param string $paymentId
+     * @param array $filters
+     *
+     * @return Payment
+     * @throws ApiException
+     */
+    public function get(string $paymentId, array $filters = []): Payment
+    {
+        return $this->send(new GetPaymentRequest($paymentId, $filters));
+    }
+
+    /**
+     * Issue a refund for the given payment.
+     *
+     * The $data parameter may either be an array of endpoint parameters, a float value to
+     * initiate a partial refund, or empty to do a full refund.
+     *
+     * @param Payment $payment
+     * @param array|float|null $data
+     *
+     * @return Refund
+     * @throws ApiException
+     */
+    public function refund(Payment $payment, $data = []): Refund
+    {
+        return $this->send(new RefundPaymentRequest($payment->id, $data));
+    }
+
+    /**
+     * Create an iterator for iterating over payments retrieved from Mollie.
+     *
+     * @param string $from The first resource ID you want to include in your list.
+     * @param int $limit
+     * @param array $filters
+     * @param bool $iterateBackwards Set to true for reverse order iteration (default is false).
+     *
+     * @return LazyCollection
+     */
+    public function iterator(?string $from = null, ?int $limit = null, array $filters = [], bool $iterateBackwards = false): LazyCollection
+    {
+        return $this->send(
+            (new GetPaginatedPaymentsRequest($from, $limit, $filters))
+                ->useIterator()
+                ->setIterationDirection($iterateBackwards)
+        );
+    }
+}

--- a/src/Http/EndpointCollection/PaymentRefundEndpointCollection.php
+++ b/src/Http/EndpointCollection/PaymentRefundEndpointCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Mollie\Api\Http\EndpointCollection;
+
+use Mollie\Api\Http\BaseEndpointCollection;
+use Mollie\Api\Http\Requests\GetPaginatedPaymentRefundsRequest;
+use Mollie\Api\Resources\RefundCollection;
+
+class PaymentRefundEndpointCollection extends BaseEndpointCollection
+{
+    /**
+     * @param string $paymentId
+     * @param array $filters
+     *
+     * @return RefundCollection
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function page(string $paymentId, array $filters = []): RefundCollection
+    {
+        return $this->send(new GetPaginatedPaymentRefundsRequest(
+            $paymentId,
+            $filters
+        ));
+    }
+}

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Mollie\Api\Http;
+
+use LogicException;
+
+abstract class Request
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected string $method;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass;
+
+    /**
+     * Get the method of the request.
+     */
+    public function getMethod(): string
+    {
+        if (!isset($this->method)) {
+            throw new LogicException('Your request is missing a HTTP method. You must add a method property like [protected Method $method = Method::GET]');
+        }
+
+        return $this->method;
+    }
+
+    public function getQuery(): array
+    {
+        return [];
+    }
+
+    public static function getTargetResourceClass(): string
+    {
+        if (empty(static::$targetResourceClass)) {
+            throw new \RuntimeException('Resource class is not set.');
+        }
+
+        return static::$targetResourceClass;
+    }
+
+    /**
+     * Resolve the resource path.
+     *
+     * @return string
+     */
+    abstract public function resolveResourcePath(): string;
+}

--- a/src/Http/Requests/GetPaginatedBalancesRequest.php
+++ b/src/Http/Requests/GetPaginatedBalancesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Http\Request;
+use Mollie\Api\Resources\BalanceCollection;
+
+class GetPaginatedBalancesRequest extends Request
+{
+    use IsPaginatedRequest;
+
+    /**
+     * Define the HTTP method.
+     */
+    protected string $method = MollieApiClient::HTTP_GET;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass = BalanceCollection::class;
+
+    /**
+     * Resolve the resource path.
+     *
+     * @return string
+     */
+    public function resolveResourcePath(): string
+    {
+        return "balances";
+    }
+}

--- a/src/Http/Requests/GetPaginatedPaymentRefundsRequest.php
+++ b/src/Http/Requests/GetPaginatedPaymentRefundsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Http\Request;
+use Mollie\Api\MollieApiClient;
+
+class GetPaginatedPaymentRefundsRequest extends Request
+{
+    use IsPaginatedRequest;
+
+    /**
+     * Define the HTTP method.
+     */
+    protected string $method = MollieApiClient::HTTP_GET;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass = \Mollie\Api\Resources\RefundCollection::class;
+
+    protected string $paymentId;
+
+    public function __construct(
+        string $paymentId,
+        array $filters = []
+    ) {
+        $this->paymentId = $paymentId;
+        $this->filters = $filters;
+    }
+
+    public function resolveResourcePath(): string
+    {
+        $id = urlencode($this->paymentId);
+
+        return "payments/{$id}/refunds";
+    }
+}

--- a/src/Http/Requests/GetPaginatedPaymentsRequest.php
+++ b/src/Http/Requests/GetPaginatedPaymentsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\IsIteratable;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Http\Request;
+use Mollie\Api\Resources\PaymentCollection;
+
+class GetPaginatedPaymentsRequest extends Request implements IsIteratable
+{
+    use IsPaginatedRequest;
+    use IsIteratableRequest;
+
+    /**
+     * Define the HTTP method.
+     */
+    protected string $method = MollieApiClient::HTTP_GET;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass = PaymentCollection::class;
+
+    /**
+     * Resolve the resource path.
+     *
+     * @return string
+     */
+    public function resolveResourcePath(): string
+    {
+        return "payments";
+    }
+}

--- a/src/Http/Requests/GetPaymentRequest.php
+++ b/src/Http/Requests/GetPaymentRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Http\Request;
+use Mollie\Api\MollieApiClient;
+
+class GetPaymentRequest extends Request
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected string $method = MollieApiClient::HTTP_GET;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass = \Mollie\Api\Resources\Payment::class;
+
+    public string $paymentId;
+
+    public array $filters;
+
+    public function __construct(
+        string $paymentId,
+        array $filters = []
+    ) {
+        // add guard method
+
+        $this->paymentId = $paymentId;
+        $this->filters = $filters;
+    }
+
+    /**
+     * Resolve the resource path.
+     *
+     * @return string
+     */
+    public function resolveResourcePath(): string
+    {
+        $id = urlencode($this->paymentId);
+
+        return "payments/{$id}";
+    }
+
+    public function getQuery(): array
+    {
+        return $this->filters;
+    }
+}

--- a/src/Http/Requests/HasJsonBody.php
+++ b/src/Http/Requests/HasJsonBody.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+trait HasJsonBody
+{
+    public array $body = [];
+
+    public function getBody(): string
+    {
+        return json_encode($this->body);
+    }
+}

--- a/src/Http/Requests/IsIteratableRequest.php
+++ b/src/Http/Requests/IsIteratableRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+trait IsIteratableRequest
+{
+    protected bool $iteratorEnabled = false;
+
+    protected bool $iterateBackwards = false;
+
+    public function iteratorEnabled(): bool
+    {
+        return $this->iteratorEnabled;
+    }
+
+    public function iteratesBackwards(): bool
+    {
+        return $this->iterateBackwards;
+    }
+
+    public function useIterator(): self
+    {
+        $this->iteratorEnabled = true;
+
+        return $this;
+    }
+
+    public function setIterationDirection(bool $iterateBackwards = false): self
+    {
+        $this->iterateBackwards = $iterateBackwards;
+
+        return $this;
+    }
+}

--- a/src/Http/Requests/IsPaginatedRequest.php
+++ b/src/Http/Requests/IsPaginatedRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+trait IsPaginatedRequest
+{
+    public ?string $from = null;
+
+    public ?int $limit = null;
+
+    public array $filters = [];
+
+    public function __construct(
+        ?string $from = null,
+        ?int $limit = null,
+        array $filters = []
+    ) {
+        $this->from = $from;
+        $this->limit = $limit;
+        $this->filters = $filters;
+    }
+
+    public function getQuery(): array
+    {
+        return array_merge([
+            'from' => $this->from,
+            'limit' => $this->limit,
+        ], $this->filters);
+    }
+}

--- a/src/Http/Requests/RefundPaymentRequest.php
+++ b/src/Http/Requests/RefundPaymentRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\HasBody;
+use Mollie\Api\Http\Request;
+use Mollie\Api\MollieApiClient;
+
+class RefundPaymentRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected string $method = MollieApiClient::HTTP_POST;
+
+    /**
+     * The resource class the request should be casted to.
+     *
+     * @var string
+     */
+    public static string $targetResourceClass = \Mollie\Api\Resources\Refund::class;
+
+    public string $paymentId;
+
+    public function __construct(
+        string $paymentId,
+        array $data
+    ) {
+        $this->paymentId = $paymentId;
+        $this->body = $data;
+    }
+
+    public function resolveResourcePath(): string
+    {
+        $id = urlencode($this->paymentId);
+
+        return "payments/{$id}/refunds";
+    }
+}

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -48,7 +48,12 @@ use Mollie\Api\Endpoints\WalletEndpoint;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Exceptions\IncompatiblePlatform;
 use Mollie\Api\Http\Adapter\MollieHttpAdapterPicker;
+use Mollie\Api\Http\EndpointCollection\BalanceEndpointCollection;
+use Mollie\Api\Http\EndpointCollection\PaymentEndpointCollection;
+use Mollie\Api\Contracts\HasBody;
+use Mollie\Api\Http\EndpointCollection\PaymentRefundEndpointCollection;
 use Mollie\Api\Idempotency\IdempotencyKeyGeneratorContract;
+use Mollie\Api\Http\Request;
 
 /**
  * @property BalanceEndpoint $balances
@@ -177,7 +182,11 @@ class MollieApiClient
     private function initializeEndpoints(): void
     {
         $endpointClasses = [
-            'balances' => BalanceEndpoint::class,
+            'balances' => BalanceEndpointCollection::class,
+            'payments' => PaymentEndpointCollection::class,
+            'paymentRefunds' => PaymentRefundEndpointCollection::class,
+
+            // 'balances' => BalanceEndpoint::class,
             'balanceReports' => BalanceReportEndpoint::class,
             'balanceTransactions' => BalanceTransactionEndpoint::class,
             'chargebacks' => ChargebackEndpoint::class,
@@ -200,9 +209,9 @@ class MollieApiClient
             'paymentChargebacks' => PaymentChargebackEndpoint::class,
             'paymentLinks' => PaymentLinkEndpoint::class,
             'paymentLinkPayments' => PaymentLinkPaymentEndpoint::class,
-            'paymentRefunds' => PaymentRefundEndpoint::class,
+            // 'paymentRefunds' => PaymentRefundEndpoint::class,
             'paymentRoutes' => PaymentRouteEndpoint::class,
-            'payments' => PaymentEndpoint::class,
+            // 'payments' => PaymentEndpoint::class,
             'permissions' => PermissionEndpoint::class,
             'profiles' => ProfileEndpoint::class,
             'profileMethods' => ProfileMethodEndpoint::class,


### PR DESCRIPTION
Should be self explanatory.

- the exposed api is not changed (=devs wouldn't need to change anything).
- endpoints can be grouped in one class (called EndpointCollection -> can be changed)
- the individual requests define the `resourceClass` they are casted to when a response is returned.

IMO the `BaseEndpointCollection` is far from optimally structured, but after all it's a POC...

Atm those endpoints are implemented

```php
$client = new MollieApiClient();
$client->setApiKey("test_xxxxxxxxxxxxxxxxxx");

$client->payments->page();
$client->payments->iterator();
$client->payments->get(..);
$client->payments->refund(..);
$client->paymentRefunds->page(..)
```