### PR TITLE
Exclude dev files and examples from Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 /.github export-ignore
+/examples export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml export-ignore
 /scoper.inc.php export-ignore


### PR DESCRIPTION
This will reduce the file size of the Composer package.