### PR TITLE
fix: wrong phpdoc return for cancelFor/cancelForId methods

### DIFF
--- a/src/Endpoints/SubscriptionEndpoint.php
+++ b/src/Endpoints/SubscriptionEndpoint.php
@@ -194,7 +194,7 @@ class SubscriptionEndpoint extends CollectionEndpointAbstract
      * @param string $subscriptionId
      * @param array $data
      *
-     * @return mixed
+     * @return Subscription
      * @throws ApiException
      */
     public function cancelFor(Customer $customer, $subscriptionId, array $data = [])
@@ -207,7 +207,7 @@ class SubscriptionEndpoint extends CollectionEndpointAbstract
      * @param string $subscriptionId
      * @param array $data
      *
-     * @return mixed
+     * @return Subscription
      * @throws ApiException
      */
     public function cancelForId($customerId, $subscriptionId, array $data = [])

--- a/src/Endpoints/SubscriptionEndpoint.php
+++ b/src/Endpoints/SubscriptionEndpoint.php
@@ -194,7 +194,7 @@ class SubscriptionEndpoint extends CollectionEndpointAbstract
      * @param string $subscriptionId
      * @param array $data
      *
-     * @return null
+     * @return mixed
      * @throws ApiException
      */
     public function cancelFor(Customer $customer, $subscriptionId, array $data = [])
@@ -207,7 +207,7 @@ class SubscriptionEndpoint extends CollectionEndpointAbstract
      * @param string $subscriptionId
      * @param array $data
      *
-     * @return null
+     * @return mixed
      * @throws ApiException
      */
     public function cancelForId($customerId, $subscriptionId, array $data = [])


### PR DESCRIPTION
the return for the subscription methods cancelFor/cancelForId in phpdoc comments is wrong. instead of null it should be mixed.

see https://docs.mollie.com/reference/cancel-subscription