### PR TITLE
Fix 752 deprecation warnings

### DIFF
--- a/src/Endpoints/PaymentLinkPaymentEndpoint.php
+++ b/src/Endpoints/PaymentLinkPaymentEndpoint.php
@@ -29,14 +29,14 @@ class PaymentLinkPaymentEndpoint extends CollectionEndpointAbstract
         return new Payment($this->client);
     }
 
-    public function pageForId(string $paymentLinkId, string $from = null, int $limit = null, array $filters = [])
+    public function pageForId(string $paymentLinkId, ?string $from = null, ?int $limit = null, array $filters = [])
     {
         $this->parentId = $paymentLinkId;
 
         return $this->rest_list($from, $limit, $filters);
     }
 
-    public function pageFor(PaymentLink $paymentLink, string $from = null, int $limit = null, array $filters = [])
+    public function pageFor(PaymentLink $paymentLink, ?string $from = null, ?int $limit = null, array $filters = [])
     {
         return $this->pageForId($paymentLink->id, $from, $limit, $filters);
     }

--- a/src/Endpoints/SettlementCaptureEndpoint.php
+++ b/src/Endpoints/SettlementCaptureEndpoint.php
@@ -36,7 +36,7 @@ class SettlementCaptureEndpoint extends CollectionEndpointAbstract
      * @return mixed
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function pageForId(string $settlementId, string $from = null, int $limit = null, array $parameters = [])
+    public function pageForId(string $settlementId, ?string $from = null, ?int $limit = null, array $parameters = [])
     {
         $this->parentId = $settlementId;
 

--- a/src/Endpoints/SettlementChargebackEndpoint.php
+++ b/src/Endpoints/SettlementChargebackEndpoint.php
@@ -39,7 +39,7 @@ class SettlementChargebackEndpoint extends CollectionEndpointAbstract
      * @return mixed
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function pageForId(string $settlementId, string $from = null, int $limit = null, array $parameters = [])
+    public function pageForId(string $settlementId, ?string $from = null, ?int $limit = null, array $parameters = [])
     {
         $this->parentId = $settlementId;
 

--- a/src/Endpoints/SettlementRefundEndpoint.php
+++ b/src/Endpoints/SettlementRefundEndpoint.php
@@ -39,7 +39,7 @@ class SettlementRefundEndpoint extends CollectionEndpointAbstract
      * @return mixed
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function pageForId(string $settlementId, string $from = null, int $limit = null, array $parameters = [])
+    public function pageForId(string $settlementId, ?string $from = null, ?int $limit = null, array $parameters = [])
     {
         $this->parentId = $settlementId;
 

--- a/src/HttpAdapter/Guzzle6And7RetryMiddlewareFactory.php
+++ b/src/HttpAdapter/Guzzle6And7RetryMiddlewareFactory.php
@@ -66,8 +66,8 @@ class Guzzle6And7RetryMiddlewareFactory
         return function (
             $retries,
             Request $request,
-            Response $response = null,
-            TransferException $exception = null
+            ?Response $response = null,
+            ?TransferException $exception = null
         ) {
             if ($retries >= static::MAX_RETRIES) {
                 return false;

--- a/src/Resources/LazyCollection.php
+++ b/src/Resources/LazyCollection.php
@@ -76,7 +76,7 @@ class LazyCollection implements IteratorAggregate
      * @param (callable(TValue, TKey): bool)|null  $callback
      * @return TValue|null
      */
-    public function first(callable $callback = null)
+    public function first(?callable $callback = null)
     {
         $iterator = $this->getIterator();
 

--- a/src/Resources/PaymentLink.php
+++ b/src/Resources/PaymentLink.php
@@ -166,7 +166,7 @@ class PaymentLink extends BaseResource
      * @param array $filters
      * @return mixed|\Mollie\Api\Resources\BaseCollection
      */
-    public function payments(string $from = null, int $limit = null, array $filters = [])
+    public function payments(?string $from = null, ?int $limit = null, array $filters = [])
     {
         return $this->client->paymentLinkPayments->pageFor(
             $this,

--- a/src/Resources/Settlement.php
+++ b/src/Resources/Settlement.php
@@ -118,7 +118,7 @@ class Settlement extends BaseResource
      * @return PaymentCollection
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function payments(int $limit = null, array $parameters = []): PaymentCollection
+    public function payments(?int $limit = null, array $parameters = []): PaymentCollection
     {
         return $this->client->settlementPayments->pageForId(
             $this->id,
@@ -136,7 +136,7 @@ class Settlement extends BaseResource
      * @return RefundCollection
      * @throws ApiException
      */
-    public function refunds(int $limit = null, array $parameters = [])
+    public function refunds(?int $limit = null, array $parameters = [])
     {
         return $this->client->settlementRefunds->pageForId(
             $this->id,
@@ -154,7 +154,7 @@ class Settlement extends BaseResource
      * @return ChargebackCollection
      * @throws ApiException
      */
-    public function chargebacks(int $limit = null, array $parameters = [])
+    public function chargebacks(?int $limit = null, array $parameters = [])
     {
         return $this->client->settlementChargebacks->pageForId(
             $this->id,
@@ -172,7 +172,7 @@ class Settlement extends BaseResource
      * @return CaptureCollection
      * @throws ApiException
      */
-    public function captures(int $limit = null, array $parameters = [])
+    public function captures(?int $limit = null, array $parameters = [])
     {
         return $this->client->settlementCaptures->pageForId(
             $this->id,


### PR DESCRIPTION
Marked parameters as nullable (`?`) to get rid of php8.4 deprecation warnings.