### PR TITLE
Allow psr/http-message:^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "nyholm/psr7": "^1.8",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.1",
-    "psr/http-message": "^2.0"
+    "psr/http-message": "^1.0|^2.0"
   },
   "require-dev": {
     "brianium/paratest": "^6.11",


### PR DESCRIPTION
As I'm using PAYUM on the top of the mollie library, I have problem to install stable 3.0 version with http-message:2.0 requirement.

Would be possible to allow older http-message which only misses return type hints?