### PR TITLE
Fix/791 data types may mess up property order

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,7 +9,7 @@ parameters:
 		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
-			count: 5
+			count: 6
 			path: src/Http/Data/DataCollection.php
 
 		-

--- a/src/Http/Data/DataCollection.php
+++ b/src/Http/Data/DataCollection.php
@@ -71,6 +71,13 @@ class DataCollection implements Countable, Resolvable
 
     public function filter($callback = null): self
     {
+        /**
+         * PHP 7.4 and below does not support nullable callbacks.
+         */
+        if ($callback === null) {
+            return new static(array_filter($this->items));
+        }
+
         return new static(array_filter($this->items, $callback));
     }
 }

--- a/src/Http/Data/DataCollection.php
+++ b/src/Http/Data/DataCollection.php
@@ -56,6 +56,14 @@ class DataCollection implements Countable, Resolvable
         return $this->items;
     }
 
+    /**
+     * @return mixed
+     */
+    public function pipe(callable $callback)
+    {
+        return $callback($this);
+    }
+
     public function map(callable $callback): self
     {
         return new static(Arr::map($this->items, $callback));

--- a/src/Traits/ComposableFromArray.php
+++ b/src/Traits/ComposableFromArray.php
@@ -2,17 +2,34 @@
 
 namespace Mollie\Api\Traits;
 
+use Mollie\Api\Contracts\Arrayable;
 use Mollie\Api\Http\Data\DataCollection;
+use ReflectionClass;
+use ReflectionParameter;
 
 trait ComposableFromArray
 {
     public static function fromArray($data = []): self
     {
-        $data = DataCollection::wrap($data)
-            ->values()
-            ->toArray();
+        $data = $data instanceof Arrayable ? $data->toArray() : $data;
 
-        /** @phpstan-ignore-next-line */
-        return new static(...$data);
+        $reflection = new ReflectionClass(static::class);
+        $parameters = $reflection->getConstructor()?->getParameters();
+
+        return DataCollection::wrap($parameters)
+            ->map(function (ReflectionParameter $parameter) use ($data) {
+                $name = $parameter->getName();
+
+                if (array_key_exists($name, $data)) {
+                    return $data[$name];
+                }
+
+                if ($parameter->isDefaultValueAvailable()) {
+                    return $parameter->getDefaultValue();
+                }
+
+                return null;
+            })
+            ->pipe(fn (DataCollection $data) => $reflection->newInstanceArgs($data->toArray()));
     }
 }

--- a/src/Traits/ComposableFromArray.php
+++ b/src/Traits/ComposableFromArray.php
@@ -14,7 +14,8 @@ trait ComposableFromArray
         $data = $data instanceof Arrayable ? $data->toArray() : $data;
 
         $reflection = new ReflectionClass(static::class);
-        $parameters = $reflection->getConstructor()?->getParameters();
+        $constructor = $reflection->getConstructor();
+        $parameters = $constructor ? $constructor->getParameters() : [];
 
         return DataCollection::wrap($parameters)
             ->map(function (ReflectionParameter $parameter) use ($data) {

--- a/src/Utils/DataTransformer.php
+++ b/src/Utils/DataTransformer.php
@@ -55,7 +55,7 @@ class DataTransformer
                 }
 
                 if ($value instanceof Arrayable) {
-                    return $value->toArray();
+                    return array_filter($value->toArray(), fn ($value) => $this->filterEmptyValues($value));
                 }
 
                 if ($value instanceof Stringable) {
@@ -68,8 +68,13 @@ class DataTransformer
 
                 return $value;
             })
-            ->filter(fn ($value) => ! empty($value) || is_bool($value))
+            ->filter(fn ($value) => $this->filterEmptyValues($value))
             ->toArray();
+    }
+
+    private function filterEmptyValues($value)
+    {
+        return ! empty($value) || is_bool($value);
     }
 
     private function transformBooleans($value)

--- a/tests/Http/Data/AddressTest.php
+++ b/tests/Http/Data/AddressTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Http\Data;
+
+use Mollie\Api\Http\Data\Address;
+use PHPUnit\Framework\TestCase;
+
+class AddressTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_address_from_array()
+    {
+        $object = Address::fromArray($data = [
+            'title' => 'Mr.',
+            'familyName' => 'Doe',
+            'organizationName' => 'Mollie',
+            'givenName' => 'John',
+            'streetAndNumber' => 'Dam 1',
+            'streetAdditional' => 'Apt 2',
+            'postalCode' => '1012JS',
+            'email' => 'john.doe@example.com',
+            'phone' => '+31201234567',
+            'city' => 'Amsterdam',
+            'country' => 'NL',
+            'region' => 'Noord-Holland',
+        ]);
+
+        $this->assertInstanceOf(Address::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Http/Data/DataCollectionTest.php
+++ b/tests/Http/Data/DataCollectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http\Data;
 
-use Mollie\Api\Http\Data\DataCollection;
 use Mollie\Api\Contracts\Arrayable;
+use Mollie\Api\Http\Data\DataCollection;
 use PHPUnit\Framework\TestCase;
 
 class DataCollectionTest extends TestCase
@@ -63,7 +63,10 @@ class DataCollectionTest extends TestCase
     public static function provideWrapSubjects()
     {
         $mockArrayable = new class implements Arrayable {
-            public function toArray(): array { return [3, 4]; }
+            public function toArray(): array
+            {
+                return [3, 4];
+            }
         };
 
         return [
@@ -101,7 +104,7 @@ class DataCollectionTest extends TestCase
         $collection = new DataCollection([1, 2, 3]);
 
         $result = $collection->pipe(function ($c) {
-            return $c->map(fn($v) => $v * 2);
+            return $c->map(fn ($v) => $v * 2);
         });
 
         $this->assertSame([2, 4, 6], $result->toArray());
@@ -123,9 +126,9 @@ class DataCollectionTest extends TestCase
     public static function provideMapCases()
     {
         return [
-            'increment' => [[1, 2, 3], fn($v) => $v + 1, [2, 3, 4]],
-            'halve' => [[2, 4, 6], fn($v) => $v / 2, [1, 2, 3]],
-            'empty' => [[], fn($v) => $v, []],
+            'increment' => [[1, 2, 3], fn ($v) => $v + 1, [2, 3, 4]],
+            'halve' => [[2, 4, 6], fn ($v) => $v / 2, [1, 2, 3]],
+            'empty' => [[], fn ($v) => $v, []],
         ];
     }
 
@@ -143,10 +146,10 @@ class DataCollectionTest extends TestCase
     public static function provideFilterCases()
     {
         return [
-            'even values' => [[1, 2, 3, 4], fn($v) => $v % 2 === 0, [1 => 2, 3 => 4]],
-            'greater than two' => [[1, 3, 5], fn($v) => $v > 2, [1 => 3, 2 => 5]],
+            'even values' => [[1, 2, 3, 4], fn ($v) => $v % 2 === 0, [1 => 2, 3 => 4]],
+            'greater than two' => [[1, 3, 5], fn ($v) => $v > 2, [1 => 3, 2 => 5]],
             'no callback' => [[1, 2, 3], null, [1, 2, 3]],
-            'empty input' => [[], fn($v) => true, []],
+            'empty input' => [[], fn ($v) => true, []],
         ];
     }
 }

--- a/tests/Http/Data/DataCollectionTest.php
+++ b/tests/Http/Data/DataCollectionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Http\Data;
+
+use Mollie\Api\Http\Data\DataCollection;
+use Mollie\Api\Contracts\Arrayable;
+use PHPUnit\Framework\TestCase;
+
+class DataCollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideArraysForConstruction
+     */
+    public function can_be_constructed_and_converted_to_array($items)
+    {
+        $collection = new DataCollection($items);
+
+        $this->assertSame($items, $collection->toArray());
+    }
+
+    public static function provideArraysForConstruction()
+    {
+        return [
+            'simple array' => [[1, 2, 3]],
+            'associative array' => [['a' => 1, 'b' => 2]],
+            'empty array' => [[]],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideArraysForCount
+     */
+    public function counts_items_correctly($items, $expectedCount)
+    {
+        $collection = new DataCollection($items);
+
+        $this->assertSame($expectedCount, $collection->count());
+    }
+
+    public static function provideArraysForCount()
+    {
+        return [
+            'four items' => [[1, 2, 3, 4], 4],
+            'empty array' => [[], 0],
+            'single associative' => [['a' => 1], 1],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideWrapSubjects
+     */
+    public function wraps_various_subjects_correctly($subject, $expected)
+    {
+        $collection = DataCollection::wrap($subject);
+
+        $this->assertInstanceOf(DataCollection::class, $collection);
+        $this->assertSame($expected, $collection->toArray());
+    }
+
+    public static function provideWrapSubjects()
+    {
+        $mockArrayable = new class implements Arrayable {
+            public function toArray(): array { return [3, 4]; }
+        };
+
+        return [
+            'array' => [[1, 2], [1, 2]],
+            'arrayable' => [$mockArrayable, [3, 4]],
+            'single value' => [5, [5]],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideValuesCollections
+     */
+    public function returns_values_collection($input, $expected)
+    {
+        $collection = new DataCollection($input);
+
+        $values = $collection->values();
+
+        $this->assertSame($expected, $values->toArray());
+    }
+
+    public static function provideValuesCollections()
+    {
+        return [
+            'assoc to values' => [['a' => 1, 'b' => 2], [1, 2]],
+            'indexed to values' => [[1, 2, 3], [1, 2, 3]],
+            'empty to values' => [[], []],
+        ];
+    }
+
+    /** @test */
+    public function can_pipe_through_callback()
+    {
+        $collection = new DataCollection([1, 2, 3]);
+
+        $result = $collection->pipe(function ($c) {
+            return $c->map(fn($v) => $v * 2);
+        });
+
+        $this->assertSame([2, 4, 6], $result->toArray());
+    }
+
+    /**
+     * @test
+     * @dataProvider provideMapCases
+     */
+    public function maps_items_correctly($input, $callback, $expected)
+    {
+        $collection = new DataCollection($input);
+
+        $mapped = $collection->map($callback);
+
+        $this->assertSame($expected, $mapped->toArray());
+    }
+
+    public static function provideMapCases()
+    {
+        return [
+            'increment' => [[1, 2, 3], fn($v) => $v + 1, [2, 3, 4]],
+            'halve' => [[2, 4, 6], fn($v) => $v / 2, [1, 2, 3]],
+            'empty' => [[], fn($v) => $v, []],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideFilterCases
+     */
+    public function filters_items_correctly($input, $callback, $expected)
+    {
+        $collection = new DataCollection($input);
+        $filtered = $collection->filter($callback);
+        $this->assertSame($expected, $filtered->toArray());
+    }
+
+    public static function provideFilterCases()
+    {
+        return [
+            'even values' => [[1, 2, 3, 4], fn($v) => $v % 2 === 0, [1 => 2, 3 => 4]],
+            'greater than two' => [[1, 3, 5], fn($v) => $v > 2, [1 => 3, 2 => 5]],
+            'no callback' => [[1, 2, 3], null, [1, 2, 3]],
+            'empty input' => [[], fn($v) => true, []],
+        ];
+    }
+}

--- a/tests/Http/Data/DataCollectionTest.php
+++ b/tests/Http/Data/DataCollectionTest.php
@@ -139,7 +139,9 @@ class DataCollectionTest extends TestCase
     public function filters_items_correctly($input, $callback, $expected)
     {
         $collection = new DataCollection($input);
+
         $filtered = $collection->filter($callback);
+
         $this->assertSame($expected, $filtered->toArray());
     }
 

--- a/tests/Http/Data/DiscountTest.php
+++ b/tests/Http/Data/DiscountTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Http\Data;
+
+use Mollie\Api\Http\Data\Discount;
+use PHPUnit\Framework\TestCase;
+
+class DiscountTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_discount_from_array()
+    {
+        $object = Discount::fromArray($data = [
+            'type' => 'percentage',
+            'value' => '10',
+        ]);
+
+        $this->assertInstanceOf(Discount::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Http/Data/EmailDetailsTest.php
+++ b/tests/Http/Data/EmailDetailsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Mollie\Api\Http\Data\EmailDetails;
+
+class EmailDetailsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_be_created_from_array()
+    {
+        $object = EmailDetails::fromArray($data = [
+            'subject' => 'Test Subject',
+            'body' => 'Test Body',
+        ]);
+
+        $this->assertInstanceOf(EmailDetails::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Http/Data/EmailDetailsTest.php
+++ b/tests/Http/Data/EmailDetailsTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use Mollie\Api\Http\Data\EmailDetails;
+use PHPUnit\Framework\TestCase;
 
 class EmailDetailsTest extends TestCase
 {

--- a/tests/Http/Data/OwnerAddressTest.php
+++ b/tests/Http/Data/OwnerAddressTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Mollie\Api\Http\Data\OwnerAddress;
+
+class OwnerAddressTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_be_created_from_array()
+    {
+        $object = OwnerAddress::fromArray($data = [
+            'country' => 'NL',
+            'streetAndNumber' => 'Dam 1',
+            'postalCode' => '1012JS',
+            'region' => 'Noord-Holland',
+            'city' => null,
+        ]);
+
+        $this->assertInstanceOf(OwnerAddress::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Http/Data/OwnerAddressTest.php
+++ b/tests/Http/Data/OwnerAddressTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use Mollie\Api\Http\Data\OwnerAddress;
+use PHPUnit\Framework\TestCase;
 
 class OwnerAddressTest extends TestCase
 {

--- a/tests/Http/Data/OwnerTest.php
+++ b/tests/Http/Data/OwnerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Http\Data;
+
+use Mollie\Api\Http\Data\Owner;
+use PHPUnit\Framework\TestCase;
+
+class OwnerTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_owner_from_array()
+    {
+        $object = Owner::fromArray($data = [
+            'email' => 'john.doe@example.com',
+            'givenName' => 'John',
+            'familyName' => 'Doe',
+            'locale' => 'nl_NL',
+        ]);
+
+        $this->assertInstanceOf(Owner::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Http/Data/PaymentDetailsTest.php
+++ b/tests/Http/Data/PaymentDetailsTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use Mollie\Api\Http\Data\PaymentDetails;
+use PHPUnit\Framework\TestCase;
 
 class PaymentDetailsTest extends TestCase
 {

--- a/tests/Http/Data/PaymentDetailsTest.php
+++ b/tests/Http/Data/PaymentDetailsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Mollie\Api\Http\Data\PaymentDetails;
+
+class PaymentDetailsTest extends TestCase
+{
+    public function testFromArrayCreatesCorrectObject()
+    {
+        $object = PaymentDetails::fromArray($data = [
+            'source' => 'banktransfer',
+            'sourceDescription' => 'Bank Transfer',
+        ]);
+
+        $this->assertInstanceOf(PaymentDetails::class, $object);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $object->$key);
+        }
+    }
+}

--- a/tests/Utils/DataTransformerTest.php
+++ b/tests/Utils/DataTransformerTest.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use Mollie\Api\Contracts\Resolvable;
 use Mollie\Api\Contracts\Stringable;
 use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Http\Data\Address;
 use Mollie\Api\Http\Data\DataCollection;
 use Mollie\Api\Http\Data\Money;
 use Mollie\Api\Http\Data\PaymentRoute;
@@ -46,12 +47,34 @@ class DataTransformerTest extends TestCase
         $pendingRequest->payload()->add('dateTime', DateTimeImmutable::createFromFormat('Y-m-d', '2024-01-01'));
         $pendingRequest->payload()->add('empty', null);
         $pendingRequest->payload()->add('valid', 'data');
+        $pendingRequest->payload()->add('address', new Address(
+            null,
+            'John',
+            'Doe',
+            null,
+            '123 Main St',
+            null,
+            '12345',
+            null,
+            null,
+            'Anytown',
+            null,
+            'BE'
+        ));
 
         $result = $this->transformer->transform($pendingRequest);
 
         $this->assertEquals('2024-01-01', $result->payload()->get('dateTime'));
         $this->assertFalse($result->payload()->has('empty'));
         $this->assertEquals('data', $result->payload()->get('valid'));
+        $this->assertEqualsCanonicalizing([
+            'givenName' => 'John',
+            'familyName' => 'Doe',
+            'streetAndNumber' => '123 Main St',
+            'postalCode' => '12345',
+            'city' => 'Anytown',
+            'country' => 'BE',
+        ], $result->payload()->get('address'));
     }
 
     /** @test */


### PR DESCRIPTION
- fixes #791
- adds `pipe()` method to `DataCollection` 