### PR TITLE
Removes nullability from delete() method, as it cannot return null

### DIFF
--- a/src/EndpointCollection/PaymentEndpointCollection.php
+++ b/src/EndpointCollection/PaymentEndpointCollection.php
@@ -87,7 +87,7 @@ class PaymentEndpointCollection extends EndpointCollection
      *
      * @throws RequestException
      */
-    public function delete(string $id, $data = []): ?Payment
+    public function delete(string $id, $data = []): Payment
     {
         return $this->cancel($id, $data);
     }


### PR DESCRIPTION
The cancel() method never returns null, thus delete can also not return null. It would be great if this fix could be merged, as it's causing typing issues in my codebase.