### PR TITLE
Fix 400 Bad Request on DELETE when store array is empty

### DIFF
--- a/src/Repositories/JsonPayloadRepository.php
+++ b/src/Repositories/JsonPayloadRepository.php
@@ -11,7 +11,7 @@ class JsonPayloadRepository extends ArrayStore implements PayloadRepository, Str
 {
     public function __toString(): string
     {
-        return @json_encode($this->store);
+        return !empty($this->store) ? @json_encode($this->store) : "";
     }
 
     public function toStream(StreamFactoryInterface $streamFactory): StreamInterface


### PR DESCRIPTION
This pull request includes a small change to the `JsonPayloadRepository` class in `src/Repositories/JsonPayloadRepository.php`. The change ensures that the `__toString` method returns an empty string if the `store` is empty, improving the method's robustness.

--- 

When the store array is empty and a DELETE request is sent (such as for revoking mandates), the request body contains an empty array. This results in a 400 Bad Request with the message: "The JSON request body does not represent an object."

Setting the value to an empty string results in an empty request body, which is valid for DELETE requests and acceptable for other methods as well.

![image](https://github.com/user-attachments/assets/027d8916-74e0-4a44-bdea-0e4d8ec6665e)
