### PR TITLE
Fix: allow array of payment methods when creating a payment

### DIFF
--- a/src/Http/Requests/CreatePaymentRequest.php
+++ b/src/Http/Requests/CreatePaymentRequest.php
@@ -50,7 +50,7 @@ class CreatePaymentRequest extends ResourceHydratableRequest implements HasPaylo
 
     private ?string $locale;
 
-    private ?string $paymentMethod;
+    private array|string|null $paymentMethod;
 
     private ?string $issuer;
 
@@ -96,7 +96,7 @@ class CreatePaymentRequest extends ResourceHydratableRequest implements HasPaylo
         ?Address $billingAddress = null,
         ?Address $shippingAddress = null,
         ?string $locale = null,
-        ?string $method = null,
+        array|string|null $method = null,
         ?string $issuer = null,
         ?string $restrictPaymentMethodsToCountry = null,
         ?array $metadata = null,


### PR DESCRIPTION
Based on the docs, the method parameter can also be an array, to limit the payment methods that are shown on the Mollie checkout page. 
[https://docs.mollie.com/reference/create-payment](https://docs.mollie.com/reference/create-payment)
