### PR TITLE
Allow description on CreatePaymentRefundRequest to be empty

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,12 @@ parameters:
 			path: src/Http/Data/DataCollection.php
 
 		-
+			message: '#^Deprecated in PHP 8\.0\: Required parameter \$amount follows optional parameter \$description\.$#'
+			identifier: parameter.requiredAfterOptional
+			count: 1
+			path: src/Http/Requests/CreatePaymentRefundRequest.php
+
+		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 1

--- a/src/Factories/CreatePaymentRefundRequestFactory.php
+++ b/src/Factories/CreatePaymentRefundRequestFactory.php
@@ -17,7 +17,7 @@ class CreatePaymentRefundRequestFactory extends RequestFactory
     {
         return new CreatePaymentRefundRequest(
             $this->paymentId,
-            $this->payload('description'),
+            $this->payload('description', ''),
             MoneyFactory::new($this->payload('amount'))->create(),
             $this->payload('metadata'),
             $this->payload('reverseRouting'),

--- a/src/Http/Requests/CreatePaymentRefundRequest.php
+++ b/src/Http/Requests/CreatePaymentRefundRequest.php
@@ -38,7 +38,7 @@ class CreatePaymentRefundRequest extends ResourceHydratableRequest implements Ha
 
     public function __construct(
         string $paymentId,
-        string $description,
+        string $description = '',
         Money $amount,
         ?array $metadata = null,
         ?bool $reverseRouting = null,

--- a/tests/Utils/DataTransformerTest.php
+++ b/tests/Utils/DataTransformerTest.php
@@ -44,7 +44,8 @@ class DataTransformerTest extends TestCase
     {
         $pendingRequest = $this->createPostRequest();
         $pendingRequest->payload()->add('dateTime', '2024-01-01T11:00:00+00:00');
-        $pendingRequest->payload()->add('empty', null);
+        $pendingRequest->payload()->add('empty', '');
+        $pendingRequest->payload()->add('null', null);
         $pendingRequest->payload()->add('valid', 'data');
         $pendingRequest->payload()->add('address', new Address(
             null,
@@ -65,6 +66,7 @@ class DataTransformerTest extends TestCase
 
         $this->assertEquals('2024-01-01T11:00:00+00:00', (string) $result->payload()->get('dateTime'));
         $this->assertFalse($result->payload()->has('empty'));
+        $this->assertFalse($result->payload()->has('null'));
         $this->assertEquals('data', $result->payload()->get('valid'));
         $this->assertEqualsCanonicalizing([
             'givenName' => 'John',


### PR DESCRIPTION
fixes #835