### PR TITLE
Fix PHPStan CI: replace ramsey/composer-install with plain composer install

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        run: composer install --no-interaction --no-progress
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/src/Resources/ResourceCollection.php
+++ b/src/Resources/ResourceCollection.php
@@ -29,7 +29,7 @@ abstract class ResourceCollection extends BaseCollection
     }
 
     /**
-     * @return $this
+     * @return static
      */
     public static function withResponse(Response $response, Connector $connector, $items = [], ?\stdClass $_links = null): self
     {


### PR DESCRIPTION
## Summary

- Fixes the PHPStan CI job that fails on every branch due to an org-level actions policy violation
- `ramsey/composer-install@v3` internally SHA-pins `actions/cache@0400d5f...` (v4.2.4), which is rejected because the org only allows tag references like `actions/cache@v4`
- Replaces with plain `composer install --no-interaction --no-progress`, matching the pattern already used by the tests workflow

## Context

The error:
```
The action actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 is not allowed
in mollie/mollie-api-php because all actions must be from a repository owned by
mollie or match one of the patterns: [...] actions/cache@v4 [...]
```

This blocks PHPStan CI on all branches, not just new PRs.

## Test plan

- [ ] PHPStan CI job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)