### PR TITLE
refactor(webhooks): bind connector to WebhookEventMapper for zero-arg asResource()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WebhookEventMapper::processPayload()` gains an optional `?string
   $signature` parameter that is threaded through to the resulting event
   and carried onto hydrated resources via `WebhookSnapshotOrigin`.
+- `WebhookEventMapper::__construct()` accepts an optional `?Connector`
+  second argument. When supplied, events produced by the mapper carry
+  the connector so `BaseEvent::asResource()` can be called with zero
+  arguments (`new WebhookEventMapper([], $mollie)` → `$event->asResource()`).
+  An explicit argument to `asResource()` still overrides the bound one.
+- `BaseEvent::asResource()` parameter is now optional when the mapper
+  was constructed with a connector. Calling it with no argument and no
+  bound connector throws a clear `LogicException` pointing at both ways
+  to supply one (BC-safe: `asResource($mollie)` still works).
 - `ResourceCollection::withOrigin()` factory as the origin-aware sibling
   of `withResponse()`.
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -99,6 +99,32 @@ match (true) {
 };
 ```
 
+#### Binding a connector to the mapper
+
+For application-level code, prefer constructing `WebhookEventMapper` with
+the connector. Events produced by that mapper will then carry the
+connector, so `asResource()` can be called with no arguments:
+
+```php
+$mapper = new WebhookEventMapper([], $mollie);
+
+$event = $mapper->processPayload($request->getParsedBody(), $signature);
+
+// No argument needed — the mapper's connector is used.
+$resource = $event->asResource();
+```
+
+Passing an explicit connector still works and overrides the bound one on
+a per-call basis:
+
+```php
+$resource = $event->asResource($otherMollie);
+```
+
+If the mapper was constructed without a connector and `asResource()` is
+called with no argument, a `LogicException` is thrown pointing at the
+two ways to supply one.
+
 #### Using custom webhook Events
 If the API is ahead of this SDK's implementation of new Events, you can create your own Events as temporary workaround and pass it into the `WebhookEventMapper`
 

--- a/src/Webhooks/Events/BaseEvent.php
+++ b/src/Webhooks/Events/BaseEvent.php
@@ -35,6 +35,13 @@ abstract class BaseEvent
      */
     public DateTimeImmutable $receivedAt;
 
+    /**
+     * Optional connector bound by {@see \Mollie\Api\Webhooks\WebhookEventMapper}.
+     * Kept private because this is plumbing: consumers should rely on
+     * {@see asResource()} which resolves this automatically.
+     */
+    private ?Connector $connector;
+
     public function __construct(
         string $id,
         string $entityId,
@@ -42,7 +49,8 @@ abstract class BaseEvent
         object $links,
         ?WebhookEntity $entity = null,
         ?string $signature = null,
-        ?DateTimeImmutable $receivedAt = null
+        ?DateTimeImmutable $receivedAt = null,
+        ?Connector $connector = null
     ) {
         $this->id = $id;
         $this->entityId = $entityId;
@@ -51,6 +59,7 @@ abstract class BaseEvent
         $this->entity = $entity;
         $this->signature = $signature;
         $this->receivedAt = $receivedAt ?? new DateTimeImmutable;
+        $this->connector = $connector;
     }
 
     abstract public static function type(): string;
@@ -70,9 +79,25 @@ abstract class BaseEvent
      * propagating the rich webhook origin (event id, signature,
      * received-at). Throws if the webhook delivery was "simple" and
      * carried no embedded entity.
+     *
+     * The $connector argument is optional when the mapper that produced
+     * this event was constructed with one (see
+     * {@see \Mollie\Api\Webhooks\WebhookEventMapper::__construct()}).
+     * An explicit argument always wins over the bound connector.
      */
-    public function asResource(Connector $connector): BaseResource
+    public function asResource(?Connector $connector = null): BaseResource
     {
+        $connector = $connector ?? $this->connector;
+
+        if ($connector === null) {
+            throw new \LogicException(
+                'No connector available to hydrate webhook resource. '
+                .'Either pass a connector to asResource(), or construct '
+                .'WebhookEventMapper with one via '
+                .'new WebhookEventMapper([], $mollie).'
+            );
+        }
+
         return $this->entity()->asResource(
             $connector,
             new WebhookSnapshotOrigin(

--- a/src/Webhooks/WebhookEventMapper.php
+++ b/src/Webhooks/WebhookEventMapper.php
@@ -3,6 +3,7 @@
 namespace Mollie\Api\Webhooks;
 
 use DateTimeImmutable;
+use Mollie\Api\Contracts\Connector;
 use Mollie\Api\Http\Data\DateTime;
 use Mollie\Api\Utils\Arr;
 use Mollie\Api\Utils\Utility;
@@ -22,9 +23,17 @@ class WebhookEventMapper
     /** @var array<string, class-string<BaseEvent>> */
     private array $map;
 
-    public function __construct(array $map = [])
+    /**
+     * Optional connector bound to this mapper. When set, events produced
+     * by {@see processPayload()} can call {@see Events\BaseEvent::asResource()}
+     * without an explicit argument. Per-call overrides still take precedence.
+     */
+    private ?Connector $connector;
+
+    public function __construct(array $map = [], ?Connector $connector = null)
     {
         $this->setup($map);
+        $this->connector = $connector;
     }
 
     /**
@@ -53,7 +62,8 @@ class WebhookEventMapper
             (object) (Arr::get($payload, '_links') ?? []),
             $this->createWebhookEntityFromPayload($payload),
             $signature,
-            new DateTimeImmutable
+            new DateTimeImmutable,
+            $this->connector
         );
     }
 
@@ -78,7 +88,8 @@ class WebhookEventMapper
         object $links,
         ?WebhookEntity $entity = null,
         ?string $signature = null,
-        ?DateTimeImmutable $receivedAt = null
+        ?DateTimeImmutable $receivedAt = null,
+        ?Connector $connector = null
     ): BaseEvent {
         if (! Arr::exists($this->map, $type)) {
             throw new \InvalidArgumentException("Unsupported event type: {$type}");
@@ -94,7 +105,8 @@ class WebhookEventMapper
             $links,
             $entity,
             $signature,
-            $receivedAt ?? new DateTimeImmutable
+            $receivedAt ?? new DateTimeImmutable,
+            $connector ?? $this->connector
         );
     }
 

--- a/tests/Webhooks/WebhookEventMapperTest.php
+++ b/tests/Webhooks/WebhookEventMapperTest.php
@@ -156,6 +156,67 @@ class WebhookEventMapperTest extends TestCase
     }
 
     /** @test */
+    public function mapper_bound_connector_enables_zero_arg_as_resource(): void
+    {
+        $client = new MockMollieClient;
+        $mapper = new WebhookEventMapper([], $client);
+
+        $payload = MockEvent::for(PaymentLinkPaid::class, 'pl_test123')
+            ->snapshot()
+            ->create();
+
+        $event = $mapper->processPayload($payload, 'sha256=sig');
+
+        /** @var PaymentLink $resource */
+        $resource = $event->asResource();
+
+        $this->assertInstanceOf(PaymentLink::class, $resource);
+        $this->assertInstanceOf(WebhookSnapshotOrigin::class, $resource->getOrigin());
+        $this->assertSame($event->id, $resource->getOrigin()->getEventId());
+        $this->assertSame('sha256=sig', $resource->getOrigin()->getSignature());
+        $client->assertSentCount(0);
+    }
+
+    /** @test */
+    public function explicit_connector_overrides_bound_connector(): void
+    {
+        $boundClient = new MockMollieClient;
+        $otherClient = new MockMollieClient;
+        $mapper = new WebhookEventMapper([], $boundClient);
+
+        $payload = MockEvent::for(PaymentLinkPaid::class, 'pl_test123')
+            ->snapshot()
+            ->create();
+
+        $event = $mapper->processPayload($payload);
+
+        /** @var PaymentLink $resource */
+        $resource = $event->asResource($otherClient);
+
+        $this->assertInstanceOf(PaymentLink::class, $resource);
+        $this->assertInstanceOf(WebhookSnapshotOrigin::class, $resource->getOrigin());
+        // The origin carries the explicitly-passed connector, not the bound one.
+        $this->assertSame($otherClient, $resource->getOrigin()->getConnector());
+        $boundClient->assertSentCount(0);
+        $otherClient->assertSentCount(0);
+    }
+
+    /** @test */
+    public function zero_arg_as_resource_without_bound_connector_throws(): void
+    {
+        $payload = MockEvent::for(PaymentLinkPaid::class, 'pl_test123')
+            ->snapshot()
+            ->create();
+
+        $event = $this->mapper->processPayload($payload);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('No connector available to hydrate webhook resource.');
+
+        $event->asResource();
+    }
+
+    /** @test */
     public function create_webhook_entity_from_payload_resolves_entity_key(): void
     {
         $payload = [


### PR DESCRIPTION
## Summary

Follow-up on #879. After Phase 2 landed, hydrating a webhook resource looks like this:

```php
\$event = (new WebhookEventMapper())->processPayload(\$body, \$signature);
\$payment = \$event->asResource(\$mollie);
```

The client is in scope when you set up the handler, so there's no good reason to pass it in again at the call site. Let the mapper remember it:

```php
\$mapper = new WebhookEventMapper([], \$mollie);
\$event  = \$mapper->processPayload(\$body, \$signature);
\$payment = \$event->asResource();   // no arg
```

Per-call override still works (`\$event->asResource(\$other)`), single-arg callers keep compiling, zero-arg on a mapper built without a connector throws a clear `LogicException` instead of a generic null dereference.

- `WebhookEventMapper::__construct()` takes an optional `?Connector` as its second argument and threads it onto every event it produces.
- `BaseEvent` stores the connector internally and uses it as the default for `asResource()`.
- `BaseEvent::asResource()` parameter becomes optional. Passing null with no bound connector throws `LogicException` with a message pointing at both fixes.

Tests cover all three paths: bound connector + zero-arg call works, explicit arg overrides the bound one, unbound mapper + zero-arg call throws.

## BC

Fully additive. The existing `asResource(Connector)` signature keeps compiling (the parameter is now optional, not removed). Zero runtime change for any caller that already passed the connector.

## Why it's separate

Kept out of #879 so that PR stays focused on the provenance refactor. This one is a quality-of-life tweak on top, easy to revert independently if it turns out to be the wrong ergonomics call.

Stacked on #879. Rebase onto `main` once that merges.