### PR TITLE
fix: change customer email property type to a nullable string

### DIFF
--- a/src/Resources/Customer.php
+++ b/src/Resources/Customer.php
@@ -32,7 +32,7 @@ class Customer extends BaseResource
     public $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $email;
 


### PR DESCRIPTION
Hi 👋 

After I added strict type to my PHP file, I got this error in production:

```
TypeError
strtolower(): Argument #1 ($string) must be of type string, null given
```
in this line of code:
```php
// $mollie is an instance of Mollie\Api\Resources\Customer
if ($user->email !== strtolower($mollie->email) && filled($user->email)) {
    ....
}
```
This PR changes the customer email property type to a nullable string.