### PR TITLE
fix: make all UpdateSalesInvoiceRequest params optional

### DIFF
--- a/src/Http/Requests/UpdateSalesInvoiceRequest.php
+++ b/src/Http/Requests/UpdateSalesInvoiceRequest.php
@@ -24,9 +24,9 @@ class UpdateSalesInvoiceRequest extends ResourceHydratableRequest implements Has
 
     private string $id;
 
-    private string $status;
+    private ?string $status;
 
-    private string $recipientIdentifier;
+    private ?string $recipientIdentifier;
 
     private ?string $memo;
 
@@ -51,8 +51,8 @@ class UpdateSalesInvoiceRequest extends ResourceHydratableRequest implements Has
 
     public function __construct(
         string $id,
-        string $status,
-        string $recipientIdentifier,
+        ?string $status = null,
+        ?string $recipientIdentifier = null,
         ?string $memo = null,
         ?string $paymentTerm = null,
         ?PaymentDetails $paymentDetails = null,

--- a/tests/Factories/UpdateSalesInvoiceRequestFactoryTest.php
+++ b/tests/Factories/UpdateSalesInvoiceRequestFactoryTest.php
@@ -63,20 +63,18 @@ class UpdateSalesInvoiceRequestFactoryTest extends TestCase
     {
         $request = UpdateSalesInvoiceRequestFactory::new(self::INVOICE_ID)
             ->withPayload([
-                'status' => 'draft',
-                'recipientIdentifier' => 'cst_12345',
-                'lines' => [
-                    [
-                        'description' => 'Product A',
-                        'quantity' => 1,
-                        'vatRate' => '21.00',
-                        'unitPrice' => [
-                            'currency' => 'EUR',
-                            'value' => '100.00',
-                        ],
-                    ],
-                ],
+                'memo' => 'Updated memo',
             ])
+            ->create();
+
+        $this->assertInstanceOf(UpdateSalesInvoiceRequest::class, $request);
+    }
+
+    /** @test */
+    public function create_returns_update_sales_invoice_request_object_with_no_optional_fields()
+    {
+        $request = UpdateSalesInvoiceRequestFactory::new(self::INVOICE_ID)
+            ->withPayload([])
             ->create();
 
         $this->assertInstanceOf(UpdateSalesInvoiceRequest::class, $request);

--- a/tests/Http/Requests/UpdateSalesInvoiceRequestTest.php
+++ b/tests/Http/Requests/UpdateSalesInvoiceRequestTest.php
@@ -6,7 +6,6 @@ use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Fake\MockResponse;
 use Mollie\Api\Http\Requests\UpdateSalesInvoiceRequest;
 use Mollie\Api\Resources\SalesInvoice;
-use Mollie\Api\Types\SalesInvoiceStatus;
 use PHPUnit\Framework\TestCase;
 
 class UpdateSalesInvoiceRequestTest extends TestCase
@@ -18,7 +17,7 @@ class UpdateSalesInvoiceRequestTest extends TestCase
             UpdateSalesInvoiceRequest::class => MockResponse::ok('sales-invoice'),
         ]);
 
-        $request = new UpdateSalesInvoiceRequest('invoice_123', SalesInvoiceStatus::PAID, 'XXXXX');
+        $request = new UpdateSalesInvoiceRequest('invoice_123');
 
         /** @var SalesInvoice */
         $salesInvoice = $client->send($request);
@@ -30,7 +29,7 @@ class UpdateSalesInvoiceRequestTest extends TestCase
     /** @test */
     public function it_resolves_correct_resource_path()
     {
-        $request = new UpdateSalesInvoiceRequest('invoice_123', SalesInvoiceStatus::PAID, 'XXXXX');
+        $request = new UpdateSalesInvoiceRequest('invoice_123');
 
         $this->assertEquals('sales-invoices/invoice_123', $request->resolveResourcePath());
     }


### PR DESCRIPTION
## Summary

Fixes #883.

The `PATCH /v2/sales-invoices/{id}` endpoint defines **no required fields** in its OpenAPI spec — every property is optional. The SDK's `UpdateSalesInvoiceRequest` incorrectly required `status` and `recipientIdentifier` as non-nullable constructor arguments, preventing callers from sending partial updates (e.g. updating only `memo` without supplying a `recipientIdentifier`).

### Changes

- `UpdateSalesInvoiceRequest`: `$status` and `$recipientIdentifier` changed from `string` to `?string = null`
- Tests updated to reflect that neither field is required at construction time; added a factory test for an empty payload

### How null values are handled

`DataTransformer::filterEmptyValues()` already strips `null` values from the JSON payload before the request is sent, so omitted fields are never transmitted to the API.

## Test plan

- [ ] `vendor/bin/phpunit tests/Http/Requests/UpdateSalesInvoiceRequestTest.php` — passes
- [ ] `vendor/bin/phpunit tests/Factories/UpdateSalesInvoiceRequestFactoryTest.php` — passes
- [ ] `vendor/bin/phpstan` — no errors