### PR TITLE
fix: add scopes query parameter to list customer mandates

### DIFF
--- a/docs/recipes/mandates/manage-mandates.md
+++ b/docs/recipes/mandates/manage-mandates.md
@@ -29,12 +29,14 @@ try {
 
 ```php
 use Mollie\Api\Http\Requests\GetPaginatedMandateRequest;
+use Mollie\Api\Types\MandateQuery;
 
 try {
     // List all mandates for a customer
     $response = $mollie->send(
         new GetPaginatedMandateRequest(
-            customerId: 'cst_8wmqcHMN4U'
+            customerId: 'cst_8wmqcHMN4U',
+            scopes: [MandateQuery::SCOPE_CUSTOMER_NOT_PRESENT]
         )
     );
 
@@ -95,3 +97,6 @@ $mandate->mandateReference; // "YOUR-COMPANY-MD13804" (optional)
   - `valid`: The mandate is valid and can be used for payments
   - `pending`: The mandate is pending and cannot be used yet
   - `invalid`: The mandate is invalid and cannot be used
+- Mandates can be filtered by scope when listing:
+  - `MandateQuery::SCOPE_CUSTOMER_PRESENT`
+  - `MandateQuery::SCOPE_CUSTOMER_NOT_PRESENT`

--- a/src/EndpointCollection/MandateEndpointCollection.php
+++ b/src/EndpointCollection/MandateEndpointCollection.php
@@ -100,12 +100,13 @@ class MandateEndpointCollection extends EndpointCollection
      *
      * @param  string  $from  The first mandate ID you want to include in your list.
      * @param  bool|array  $testmode
+     * @param  string[]|null  $scopes  Filter mandates by their scope. See \Mollie\Api\Types\MandateQuery.
      *
      * @throws RequestException
      */
-    public function pageFor(Customer $customer, ?string $from = null, ?int $limit = null, $testmode = false): MandateCollection
+    public function pageFor(Customer $customer, ?string $from = null, ?int $limit = null, $testmode = false, ?array $scopes = null): MandateCollection
     {
-        return $this->pageForId($customer->id, $from, $limit, $testmode);
+        return $this->pageForId($customer->id, $from, $limit, $testmode, $scopes);
     }
 
     /**
@@ -113,16 +114,17 @@ class MandateEndpointCollection extends EndpointCollection
      *
      * @param  string  $from  The first mandate ID you want to include in your list.
      * @param  bool|array  $testmode
+     * @param  string[]|null  $scopes  Filter mandates by their scope. See \Mollie\Api\Types\MandateQuery.
      *
      * @throws RequestException
      */
-    public function pageForId(string $customerId, ?string $from = null, ?int $limit = null, $testmode = false): MandateCollection
+    public function pageForId(string $customerId, ?string $from = null, ?int $limit = null, $testmode = false, ?array $scopes = null): MandateCollection
     {
         $testmode = Utility::extractBool($testmode, 'testmode', false);
 
         /** @var MandateCollection */
         return $this->send(
-            (new GetPaginatedMandateRequest($customerId, $from, $limit))->test($testmode)
+            (new GetPaginatedMandateRequest($customerId, $from, $limit, $scopes))->test($testmode)
         );
     }
 
@@ -132,15 +134,17 @@ class MandateEndpointCollection extends EndpointCollection
      * @param  string  $from  The first mandate ID you want to include in your list.
      * @param  bool|array  $testmode
      * @param  bool  $iterateBackwards  Set to true for reverse order iteration (default is false).
+     * @param  string[]|null  $scopes  Filter mandates by their scope. See \Mollie\Api\Types\MandateQuery.
      */
     public function iteratorFor(
         Customer $customer,
         ?string $from = null,
         ?int $limit = null,
         $testmode = false,
-        bool $iterateBackwards = false
+        bool $iterateBackwards = false,
+        ?array $scopes = null
     ): LazyCollection {
-        return $this->iteratorForId($customer->id, $from, $limit, $testmode, $iterateBackwards);
+        return $this->iteratorForId($customer->id, $from, $limit, $testmode, $iterateBackwards, $scopes);
     }
 
     /**
@@ -149,18 +153,20 @@ class MandateEndpointCollection extends EndpointCollection
      * @param  string  $from  The first mandate ID you want to include in your list.
      * @param  bool|array  $testmode
      * @param  bool  $iterateBackwards  Set to true for reverse order iteration (default is false).
+     * @param  string[]|null  $scopes  Filter mandates by their scope. See \Mollie\Api\Types\MandateQuery.
      */
     public function iteratorForId(
         string $customerId,
         ?string $from = null,
         ?int $limit = null,
         $testmode = false,
-        bool $iterateBackwards = false
+        bool $iterateBackwards = false,
+        ?array $scopes = null
     ): LazyCollection {
         $testmode = Utility::extractBool($testmode, 'testmode', false);
 
         return $this->send(
-            (new GetPaginatedMandateRequest($customerId, $from, $limit))
+            (new GetPaginatedMandateRequest($customerId, $from, $limit, $scopes))
                 ->useIterator()
                 ->setIterationDirection($iterateBackwards)
                 ->test($testmode)

--- a/src/Http/Requests/GetPaginatedMandateRequest.php
+++ b/src/Http/Requests/GetPaginatedMandateRequest.php
@@ -18,11 +18,16 @@ class GetPaginatedMandateRequest extends PaginatedRequest implements IsIteratabl
 
     private string $customerId;
 
-    public function __construct(string $customerId, ?string $from = null, ?int $limit = null)
+    /**
+     * @param  string[]|null  $scopes  Filter mandates by their scope. See \Mollie\Api\Types\MandateQuery.
+     */
+    public function __construct(string $customerId, ?string $from = null, ?int $limit = null, ?array $scopes = null)
     {
         $this->customerId = $customerId;
 
         parent::__construct($from, $limit);
+
+        $this->query()->add('scopes', $scopes);
     }
 
     public function resolveResourcePath(): string

--- a/src/Types/MandateQuery.php
+++ b/src/Types/MandateQuery.php
@@ -9,7 +9,10 @@ class MandateQuery
 {
     const SCOPE_CUSTOMER_PRESENT = 'customer-present';
 
+    const SCOPE_CUSTOMER_NOT_PRESENT = 'customer-not-present';
+
     const SCOPES = [
         self::SCOPE_CUSTOMER_PRESENT,
+        self::SCOPE_CUSTOMER_NOT_PRESENT,
     ];
 }

--- a/src/Types/MandateQuery.php
+++ b/src/Types/MandateQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Mollie\Api\Types;
+
+/**
+ * @link https://docs.mollie.com/reference/list-mandates
+ */
+class MandateQuery
+{
+    const SCOPE_CUSTOMER_PRESENT = 'customer-present';
+
+    const SCOPES = [
+        self::SCOPE_CUSTOMER_PRESENT,
+    ];
+}

--- a/tests/EndpointCollection/MandateEndpointCollectionTest.php
+++ b/tests/EndpointCollection/MandateEndpointCollectionTest.php
@@ -5,6 +5,7 @@ namespace Tests\EndpointCollection;
 use DateTimeImmutable;
 use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\CreateMandateRequest;
 use Mollie\Api\Http\Requests\GetMandateRequest;
 use Mollie\Api\Http\Requests\GetPaginatedMandateRequest;
@@ -12,6 +13,7 @@ use Mollie\Api\Http\Requests\RevokeMandateRequest;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\MandateCollection;
+use Mollie\Api\Types\MandateQuery;
 use PHPUnit\Framework\TestCase;
 
 class MandateEndpointCollectionTest extends TestCase
@@ -90,6 +92,28 @@ class MandateEndpointCollectionTest extends TestCase
         $this->assertCount(1, $mandates);
 
         $this->assertMandate($mandates[0]);
+    }
+
+    /** @test */
+    public function page_for_with_scopes()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedMandateRequest::class => MockResponse::ok('mandate-list'),
+        ]);
+
+        $customer = new Customer($client);
+        $customer->id = 'cst_4qqhO89gsT';
+
+        $client->mandates->pageFor($customer, null, null, false, [MandateQuery::SCOPE_CUSTOMER_PRESENT]);
+
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $this->assertStringContainsString(
+                'scopes%5B0%5D=customer-present',
+                $pendingRequest->getUri()->getQuery()
+            );
+
+            return true;
+        });
     }
 
     protected function assertMandate(Mandate $mandate)

--- a/tests/Http/Requests/GetPaginatedMandateRequestTest.php
+++ b/tests/Http/Requests/GetPaginatedMandateRequestTest.php
@@ -5,10 +5,12 @@ namespace Tests\Http\Requests;
 use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Fake\MockResponse;
 use Mollie\Api\Fake\SequenceMockResponse;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\DynamicGetRequest;
 use Mollie\Api\Http\Requests\GetPaginatedMandateRequest;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\MandateCollection;
+use Mollie\Api\Types\MandateQuery;
 use PHPUnit\Framework\TestCase;
 
 class GetPaginatedMandateRequestTest extends TestCase
@@ -66,5 +68,48 @@ class GetPaginatedMandateRequestTest extends TestCase
         $request = new GetPaginatedMandateRequest($customerId);
 
         $this->assertEquals("customers/{$customerId}/mandates", $request->resolveResourcePath());
+    }
+
+    /** @test */
+    public function it_does_not_include_scopes_in_query_by_default()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedMandateRequest::class => MockResponse::ok('mandate-list'),
+        ]);
+
+        $client->send(new GetPaginatedMandateRequest('cst_kEn1PlbGa'));
+
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $this->assertStringNotContainsString('scopes', $pendingRequest->getUri()->getQuery());
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_sends_scopes_as_array_in_query()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedMandateRequest::class => MockResponse::ok('mandate-list'),
+        ]);
+
+        $request = new GetPaginatedMandateRequest(
+            'cst_kEn1PlbGa',
+            null,
+            null,
+            [MandateQuery::SCOPE_CUSTOMER_PRESENT]
+        );
+
+        $client->send($request);
+
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $query = $pendingRequest->getUri()->getQuery();
+
+            // http_build_query renders array params as scopes[0]=customer-present
+            // which Mollie accepts as the standard scopes[]=customer-present form.
+            $this->assertStringContainsString('scopes%5B0%5D=customer-present', $query);
+
+            return true;
+        });
     }
 }

--- a/tests/Http/Requests/GetPaginatedMandateRequestTest.php
+++ b/tests/Http/Requests/GetPaginatedMandateRequestTest.php
@@ -97,7 +97,10 @@ class GetPaginatedMandateRequestTest extends TestCase
             'cst_kEn1PlbGa',
             null,
             null,
-            [MandateQuery::SCOPE_CUSTOMER_PRESENT]
+            [
+                MandateQuery::SCOPE_CUSTOMER_PRESENT,
+                MandateQuery::SCOPE_CUSTOMER_NOT_PRESENT,
+            ]
         );
 
         $client->send($request);
@@ -108,6 +111,7 @@ class GetPaginatedMandateRequestTest extends TestCase
             // http_build_query renders array params as scopes[0]=customer-present
             // which Mollie accepts as the standard scopes[]=customer-present form.
             $this->assertStringContainsString('scopes%5B0%5D=customer-present', $query);
+            $this->assertStringContainsString('scopes%5B1%5D=customer-not-present', $query);
 
             return true;
         });


### PR DESCRIPTION
## Summary

Closes #886.

`GET /v2/customers/{customerId}/mandates` accepts an optional `scopes[]` query parameter for filtering by usage context (e.g. `scopes[]=customer-present`) — see [list-mandates](https://docs.mollie.com/reference/list-mandates). The SDK didn't expose it, so callers had to drop down to the HTTP client to filter customer-present mandates.

- `GetPaginatedMandateRequest`: new optional `?array $scopes = null` constructor arg, merged into the request query.
- New `Mollie\Api\Types\MandateQuery` with `SCOPE_CUSTOMER_PRESENT` and `SCOPE_CUSTOMER_NOT_PRESENT` so callers don't have to know the literal strings.
- `MandateEndpointCollection::pageFor` / `pageForId` / `iteratorFor` / `iteratorForId` thread the parameter through. Added at the end of each signature to keep existing call sites untouched.
