### PR TITLE
fix: pass settlement pagination filters

### DIFF
--- a/src/Factories/GetPaginatedSettlementsRequestFactory.php
+++ b/src/Factories/GetPaginatedSettlementsRequestFactory.php
@@ -12,6 +12,9 @@ class GetPaginatedSettlementsRequestFactory extends RequestFactory
             $this->query('from'),
             $this->query('limit'),
             $this->query('balanceId'),
+            $this->query('year'),
+            $this->query('month'),
+            $this->query('currencies'),
         );
     }
 }

--- a/src/Http/Requests/GetPaginatedSettlementsRequest.php
+++ b/src/Http/Requests/GetPaginatedSettlementsRequest.php
@@ -18,12 +18,18 @@ class GetPaginatedSettlementsRequest extends PaginatedRequest implements IsItera
     public function __construct(
         ?string $from = null,
         ?int $limit = null,
-        ?string $balanceId = null
+        ?string $balanceId = null,
+        ?string $year = null,
+        ?string $month = null,
+        ?string $currencies = null
     ) {
         parent::__construct($from, $limit);
 
         $this->query()
-            ->add('balanceId', $balanceId);
+            ->add('balanceId', $balanceId)
+            ->add('year', $year)
+            ->add('month', $month)
+            ->add('currencies', $currencies);
     }
 
     /**

--- a/tests/EndpointCollection/SettlementsEndpointCollectionTest.php
+++ b/tests/EndpointCollection/SettlementsEndpointCollectionTest.php
@@ -7,6 +7,7 @@ use Mollie\Api\Fake\MockResponse;
 use Mollie\Api\Http\Requests\DynamicGetRequest;
 use Mollie\Api\Http\Requests\GetPaginatedSettlementsRequest;
 use Mollie\Api\Http\Requests\GetSettlementRequest;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Resources\Settlement;
 use Mollie\Api\Resources\SettlementCollection;
 use PHPUnit\Framework\TestCase;
@@ -57,13 +58,25 @@ class SettlementsEndpointCollectionTest extends TestCase
     {
         $client = new MockMollieClient([
             GetPaginatedSettlementsRequest::class => MockResponse::ok('settlement-list'),
-        ]);
+        ], true);
 
         /** @var SettlementCollection $settlements */
-        $settlements = $client->settlements->page('stl_123', 50, ['reference' => 'test']);
+        $settlements = $client->settlements->page('stl_123', 50, ['year' => '2024', 'month' => '04']);
 
         $this->assertInstanceOf(SettlementCollection::class, $settlements);
         $this->assertGreaterThan(0, $settlements->count());
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $this->assertEquals([
+                'from' => 'stl_123',
+                'limit' => 50,
+                'balanceId' => null,
+                'year' => '2024',
+                'month' => '04',
+                'currencies' => null,
+            ], $pendingRequest->getRequest()->query()->all());
+
+            return true;
+        });
 
         foreach ($settlements as $settlement) {
             $this->assertSettlement($settlement);

--- a/tests/EndpointCollection/SettlementsEndpointCollectionTest.php
+++ b/tests/EndpointCollection/SettlementsEndpointCollectionTest.php
@@ -4,10 +4,10 @@ namespace Tests\EndpointCollection;
 
 use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\DynamicGetRequest;
 use Mollie\Api\Http\Requests\GetPaginatedSettlementsRequest;
 use Mollie\Api\Http\Requests\GetSettlementRequest;
-use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Resources\Settlement;
 use Mollie\Api\Resources\SettlementCollection;
 use PHPUnit\Framework\TestCase;

--- a/tests/Factories/GetPaginatedSettlementsRequestFactoryTest.php
+++ b/tests/Factories/GetPaginatedSettlementsRequestFactoryTest.php
@@ -16,10 +16,21 @@ class GetPaginatedSettlementsRequestFactoryTest extends TestCase
                 'from' => 'stl_12345',
                 'limit' => 50,
                 'balanceId' => 'bal_12345',
+                'year' => '2024',
+                'month' => '04',
+                'currencies' => 'EUR,GBP',
             ])
             ->create();
 
         $this->assertInstanceOf(GetPaginatedSettlementsRequest::class, $request);
+        $this->assertEquals([
+            'from' => 'stl_12345',
+            'limit' => 50,
+            'balanceId' => 'bal_12345',
+            'year' => '2024',
+            'month' => '04',
+            'currencies' => 'EUR,GBP',
+        ], $request->query()->all());
     }
 
     /** @test */


### PR DESCRIPTION
## Summary

`$mollie->settlements->page(..., filters: [...])` accepted filters at the endpoint layer, but the request factory only forwarded `from`, `limit`, and `balanceId`. That meant calls like year/month filtering still sent `/v2/settlements?limit=50` and returned everything.

This wires the documented settlement list filters through the request object: `year`, `month`, and `currencies`, alongside the existing `balanceId`. The endpoint regression checks the actual pending request query so this does not silently drop filters again.

## Test plan

- `vendor/bin/phpunit tests/EndpointCollection/SettlementsEndpointCollectionTest.php tests/Factories/GetPaginatedSettlementsRequestFactoryTest.php tests/Http/Requests/GetPaginatedSettlementsRequestTest.php`
- `composer test`