### PR TITLE
Add new webhook event types

### DIFF
--- a/src/Fake/Responses/business-account-transfer.json
+++ b/src/Fake/Responses/business-account-transfer.json
@@ -1,0 +1,21 @@
+{
+  "resource": "business-account-transfer",
+  "id": "{{ RESOURCE_ID }}",
+  "amount": {
+    "currency": "EUR",
+    "value": "100.00"
+  },
+  "status": "processed",
+  "description": "Business account transfer",
+  "createdAt": "2023-12-25T10:30:54+00:00",
+  "_links": {
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/dispute.json
+++ b/src/Fake/Responses/dispute.json
@@ -1,0 +1,16 @@
+{
+  "resource": "dispute",
+  "id": "{{ RESOURCE_ID }}",
+  "status": "open",
+  "createdAt": "2023-12-25T10:30:54+00:00",
+  "_links": {
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/file.json
+++ b/src/Fake/Responses/file.json
@@ -1,0 +1,16 @@
+{
+  "resource": "file",
+  "id": "{{ RESOURCE_ID }}",
+  "status": "accepted",
+  "createdAt": "2023-12-25T10:30:54+00:00",
+  "_links": {
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/payout.json
+++ b/src/Fake/Responses/payout.json
@@ -1,0 +1,21 @@
+{
+  "resource": "payout",
+  "id": "{{ RESOURCE_ID }}",
+  "amount": {
+    "currency": "EUR",
+    "value": "100.00"
+  },
+  "status": "completed",
+  "description": "Payout",
+  "createdAt": "2023-12-25T10:30:54+00:00",
+  "_links": {
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/unmatched-credit-transfer.json
+++ b/src/Fake/Responses/unmatched-credit-transfer.json
@@ -1,0 +1,16 @@
+{
+  "resource": "unmatched-credit-transfer",
+  "id": "{{ RESOURCE_ID }}",
+  "status": "received",
+  "createdAt": "2023-12-25T10:30:54+00:00",
+  "_links": {
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferBlocked.php
+++ b/src/Webhooks/Events/BusinessAccountTransferBlocked.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferBlocked extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_BLOCKED;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferFailed.php
+++ b/src/Webhooks/Events/BusinessAccountTransferFailed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferFailed extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_FAILED;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferInitiated.php
+++ b/src/Webhooks/Events/BusinessAccountTransferInitiated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferInitiated extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_INITIATED;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferPendingReview.php
+++ b/src/Webhooks/Events/BusinessAccountTransferPendingReview.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferPendingReview extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_PENDING_REVIEW;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferProcessed.php
+++ b/src/Webhooks/Events/BusinessAccountTransferProcessed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferProcessed extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_PROCESSED;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferRequested.php
+++ b/src/Webhooks/Events/BusinessAccountTransferRequested.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferRequested extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_REQUESTED;
+    }
+}

--- a/src/Webhooks/Events/BusinessAccountTransferReturned.php
+++ b/src/Webhooks/Events/BusinessAccountTransferReturned.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class BusinessAccountTransferReturned extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::BUSINESS_ACCOUNT_TRANSFER_RETURNED;
+    }
+}

--- a/src/Webhooks/Events/DisputeCreated.php
+++ b/src/Webhooks/Events/DisputeCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class DisputeCreated extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::DISPUTE_CREATED;
+    }
+}

--- a/src/Webhooks/Events/DisputeResolved.php
+++ b/src/Webhooks/Events/DisputeResolved.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class DisputeResolved extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::DISPUTE_RESOLVED;
+    }
+}

--- a/src/Webhooks/Events/DisputeUpdated.php
+++ b/src/Webhooks/Events/DisputeUpdated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class DisputeUpdated extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::DISPUTE_UPDATED;
+    }
+}

--- a/src/Webhooks/Events/FileAccepted.php
+++ b/src/Webhooks/Events/FileAccepted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class FileAccepted extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::FILE_ACCEPTED;
+    }
+}

--- a/src/Webhooks/Events/FileFailed.php
+++ b/src/Webhooks/Events/FileFailed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class FileFailed extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::FILE_FAILED;
+    }
+}

--- a/src/Webhooks/Events/FileRejected.php
+++ b/src/Webhooks/Events/FileRejected.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class FileRejected extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::FILE_REJECTED;
+    }
+}

--- a/src/Webhooks/Events/PayoutCanceled.php
+++ b/src/Webhooks/Events/PayoutCanceled.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class PayoutCanceled extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::PAYOUT_CANCELED;
+    }
+}

--- a/src/Webhooks/Events/PayoutCompleted.php
+++ b/src/Webhooks/Events/PayoutCompleted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class PayoutCompleted extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::PAYOUT_COMPLETED;
+    }
+}

--- a/src/Webhooks/Events/PayoutFailed.php
+++ b/src/Webhooks/Events/PayoutFailed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class PayoutFailed extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::PAYOUT_FAILED;
+    }
+}

--- a/src/Webhooks/Events/PayoutInitiated.php
+++ b/src/Webhooks/Events/PayoutInitiated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class PayoutInitiated extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::PAYOUT_INITIATED;
+    }
+}

--- a/src/Webhooks/Events/PayoutProcessingAtBank.php
+++ b/src/Webhooks/Events/PayoutProcessingAtBank.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class PayoutProcessingAtBank extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::PAYOUT_PROCESSING_AT_BANK;
+    }
+}

--- a/src/Webhooks/Events/UnmatchedCreditTransferExpired.php
+++ b/src/Webhooks/Events/UnmatchedCreditTransferExpired.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class UnmatchedCreditTransferExpired extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::UNMATCHED_CREDIT_TRANSFER_EXPIRED;
+    }
+}

--- a/src/Webhooks/Events/UnmatchedCreditTransferMatched.php
+++ b/src/Webhooks/Events/UnmatchedCreditTransferMatched.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class UnmatchedCreditTransferMatched extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::UNMATCHED_CREDIT_TRANSFER_MATCHED;
+    }
+}

--- a/src/Webhooks/Events/UnmatchedCreditTransferReceived.php
+++ b/src/Webhooks/Events/UnmatchedCreditTransferReceived.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class UnmatchedCreditTransferReceived extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::UNMATCHED_CREDIT_TRANSFER_RECEIVED;
+    }
+}

--- a/src/Webhooks/Events/UnmatchedCreditTransferReturned.php
+++ b/src/Webhooks/Events/UnmatchedCreditTransferReturned.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Api\Webhooks\Events;
+
+use Mollie\Api\Webhooks\WebhookEventType;
+
+class UnmatchedCreditTransferReturned extends BaseEvent
+{
+    public static function type(): string
+    {
+        return WebhookEventType::UNMATCHED_CREDIT_TRANSFER_RETURNED;
+    }
+}

--- a/src/Webhooks/WebhookEventMapper.php
+++ b/src/Webhooks/WebhookEventMapper.php
@@ -8,13 +8,35 @@ use Mollie\Api\Utils\Arr;
 use Mollie\Api\Utils\Utility;
 use Mollie\Api\Webhooks\Events\BalanceTransactionCreated;
 use Mollie\Api\Webhooks\Events\BaseEvent;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferBlocked;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferFailed;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferInitiated;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferPendingReview;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferProcessed;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferRequested;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferReturned;
 use Mollie\Api\Webhooks\Events\ConnectBalanceTransferFailed;
 use Mollie\Api\Webhooks\Events\ConnectBalanceTransferSucceeded;
+use Mollie\Api\Webhooks\Events\DisputeCreated;
+use Mollie\Api\Webhooks\Events\DisputeResolved;
+use Mollie\Api\Webhooks\Events\DisputeUpdated;
+use Mollie\Api\Webhooks\Events\FileAccepted;
+use Mollie\Api\Webhooks\Events\FileFailed;
+use Mollie\Api\Webhooks\Events\FileRejected;
 use Mollie\Api\Webhooks\Events\PaymentLinkPaid;
+use Mollie\Api\Webhooks\Events\PayoutCanceled;
+use Mollie\Api\Webhooks\Events\PayoutCompleted;
+use Mollie\Api\Webhooks\Events\PayoutFailed;
+use Mollie\Api\Webhooks\Events\PayoutInitiated;
+use Mollie\Api\Webhooks\Events\PayoutProcessingAtBank;
 use Mollie\Api\Webhooks\Events\SalesInvoiceCanceled;
 use Mollie\Api\Webhooks\Events\SalesInvoiceCreated;
 use Mollie\Api\Webhooks\Events\SalesInvoiceIssued;
 use Mollie\Api\Webhooks\Events\SalesInvoicePaid;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferExpired;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferMatched;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferReceived;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferReturned;
 
 class WebhookEventMapper
 {
@@ -103,8 +125,30 @@ class WebhookEventMapper
         $this->map = array_merge([
             PaymentLinkPaid::type() => PaymentLinkPaid::class,
             BalanceTransactionCreated::type() => BalanceTransactionCreated::class,
+            PayoutInitiated::type() => PayoutInitiated::class,
+            PayoutProcessingAtBank::type() => PayoutProcessingAtBank::class,
+            PayoutCompleted::type() => PayoutCompleted::class,
+            PayoutCanceled::type() => PayoutCanceled::class,
+            PayoutFailed::type() => PayoutFailed::class,
             ConnectBalanceTransferFailed::type() => ConnectBalanceTransferFailed::class,
             ConnectBalanceTransferSucceeded::type() => ConnectBalanceTransferSucceeded::class,
+            DisputeCreated::type() => DisputeCreated::class,
+            DisputeResolved::type() => DisputeResolved::class,
+            DisputeUpdated::type() => DisputeUpdated::class,
+            FileAccepted::type() => FileAccepted::class,
+            FileRejected::type() => FileRejected::class,
+            FileFailed::type() => FileFailed::class,
+            UnmatchedCreditTransferReceived::type() => UnmatchedCreditTransferReceived::class,
+            UnmatchedCreditTransferMatched::type() => UnmatchedCreditTransferMatched::class,
+            UnmatchedCreditTransferReturned::type() => UnmatchedCreditTransferReturned::class,
+            UnmatchedCreditTransferExpired::type() => UnmatchedCreditTransferExpired::class,
+            BusinessAccountTransferRequested::type() => BusinessAccountTransferRequested::class,
+            BusinessAccountTransferInitiated::type() => BusinessAccountTransferInitiated::class,
+            BusinessAccountTransferPendingReview::type() => BusinessAccountTransferPendingReview::class,
+            BusinessAccountTransferProcessed::type() => BusinessAccountTransferProcessed::class,
+            BusinessAccountTransferFailed::type() => BusinessAccountTransferFailed::class,
+            BusinessAccountTransferBlocked::type() => BusinessAccountTransferBlocked::class,
+            BusinessAccountTransferReturned::type() => BusinessAccountTransferReturned::class,
             SalesInvoiceCreated::type() => SalesInvoiceCreated::class,
             SalesInvoiceIssued::type() => SalesInvoiceIssued::class,
             SalesInvoiceCanceled::type() => SalesInvoiceCanceled::class,

--- a/src/Webhooks/WebhookEventType.php
+++ b/src/Webhooks/WebhookEventType.php
@@ -15,10 +15,52 @@ class WebhookEventType
     public const BALANCE_TRANSACTION_CREATED = 'balance-transaction.created';
 
     /**
+     * Payout events
+     */
+    public const PAYOUT_INITIATED = 'payout.initiated';
+    public const PAYOUT_PROCESSING_AT_BANK = 'payout.processing-at-bank';
+    public const PAYOUT_COMPLETED = 'payout.completed';
+    public const PAYOUT_CANCELED = 'payout.canceled';
+    public const PAYOUT_FAILED = 'payout.failed';
+
+    /**
      * Connect balance transfer events
      */
     public const CONNECT_BALANCE_TRANSFER_FAILED = 'connect-balance-transfer.failed';
     public const CONNECT_BALANCE_TRANSFER_SUCCEEDED = 'connect-balance-transfer.succeeded';
+
+    /**
+     * Dispute events
+     */
+    public const DISPUTE_CREATED = 'dispute.created';
+    public const DISPUTE_RESOLVED = 'dispute.resolved';
+    public const DISPUTE_UPDATED = 'dispute.updated';
+
+    /**
+     * File events
+     */
+    public const FILE_ACCEPTED = 'file.accepted';
+    public const FILE_REJECTED = 'file.rejected';
+    public const FILE_FAILED = 'file.failed';
+
+    /**
+     * Unmatched credit transfer events
+     */
+    public const UNMATCHED_CREDIT_TRANSFER_RECEIVED = 'unmatched-credit-transfer.received';
+    public const UNMATCHED_CREDIT_TRANSFER_MATCHED = 'unmatched-credit-transfer.matched';
+    public const UNMATCHED_CREDIT_TRANSFER_RETURNED = 'unmatched-credit-transfer.returned';
+    public const UNMATCHED_CREDIT_TRANSFER_EXPIRED = 'unmatched-credit-transfer.expired';
+
+    /**
+     * Business account transfer events
+     */
+    public const BUSINESS_ACCOUNT_TRANSFER_REQUESTED = 'business-account-transfer.requested';
+    public const BUSINESS_ACCOUNT_TRANSFER_INITIATED = 'business-account-transfer.initiated';
+    public const BUSINESS_ACCOUNT_TRANSFER_PENDING_REVIEW = 'business-account-transfer.pending-review';
+    public const BUSINESS_ACCOUNT_TRANSFER_PROCESSED = 'business-account-transfer.processed';
+    public const BUSINESS_ACCOUNT_TRANSFER_FAILED = 'business-account-transfer.failed';
+    public const BUSINESS_ACCOUNT_TRANSFER_BLOCKED = 'business-account-transfer.blocked';
+    public const BUSINESS_ACCOUNT_TRANSFER_RETURNED = 'business-account-transfer.returned';
 
     /**
      * Sales invoice events
@@ -52,8 +94,30 @@ class WebhookEventType
         return [
             self::PAYMENT_LINK_PAID,
             self::BALANCE_TRANSACTION_CREATED,
+            self::PAYOUT_INITIATED,
+            self::PAYOUT_PROCESSING_AT_BANK,
+            self::PAYOUT_COMPLETED,
+            self::PAYOUT_CANCELED,
+            self::PAYOUT_FAILED,
             self::CONNECT_BALANCE_TRANSFER_FAILED,
             self::CONNECT_BALANCE_TRANSFER_SUCCEEDED,
+            self::DISPUTE_CREATED,
+            self::DISPUTE_RESOLVED,
+            self::DISPUTE_UPDATED,
+            self::FILE_ACCEPTED,
+            self::FILE_REJECTED,
+            self::FILE_FAILED,
+            self::UNMATCHED_CREDIT_TRANSFER_RECEIVED,
+            self::UNMATCHED_CREDIT_TRANSFER_MATCHED,
+            self::UNMATCHED_CREDIT_TRANSFER_RETURNED,
+            self::UNMATCHED_CREDIT_TRANSFER_EXPIRED,
+            self::BUSINESS_ACCOUNT_TRANSFER_REQUESTED,
+            self::BUSINESS_ACCOUNT_TRANSFER_INITIATED,
+            self::BUSINESS_ACCOUNT_TRANSFER_PENDING_REVIEW,
+            self::BUSINESS_ACCOUNT_TRANSFER_PROCESSED,
+            self::BUSINESS_ACCOUNT_TRANSFER_FAILED,
+            self::BUSINESS_ACCOUNT_TRANSFER_BLOCKED,
+            self::BUSINESS_ACCOUNT_TRANSFER_RETURNED,
             self::SALES_INVOICE_CREATED,
             self::SALES_INVOICE_ISSUED,
             self::SALES_INVOICE_CANCELED,

--- a/tests/Webhooks/WebhookEventMapperTest.php
+++ b/tests/Webhooks/WebhookEventMapperTest.php
@@ -6,7 +6,35 @@ use Mollie\Api\Fake\MockEvent;
 use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Resources\PaymentLink;
 use Mollie\Api\Webhooks\Events\BalanceTransactionCreated;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferBlocked;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferFailed;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferInitiated;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferPendingReview;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferProcessed;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferRequested;
+use Mollie\Api\Webhooks\Events\BusinessAccountTransferReturned;
+use Mollie\Api\Webhooks\Events\ConnectBalanceTransferFailed;
+use Mollie\Api\Webhooks\Events\ConnectBalanceTransferSucceeded;
+use Mollie\Api\Webhooks\Events\DisputeCreated;
+use Mollie\Api\Webhooks\Events\DisputeResolved;
+use Mollie\Api\Webhooks\Events\DisputeUpdated;
+use Mollie\Api\Webhooks\Events\FileAccepted;
+use Mollie\Api\Webhooks\Events\FileFailed;
+use Mollie\Api\Webhooks\Events\FileRejected;
 use Mollie\Api\Webhooks\Events\PaymentLinkPaid;
+use Mollie\Api\Webhooks\Events\PayoutCanceled;
+use Mollie\Api\Webhooks\Events\PayoutCompleted;
+use Mollie\Api\Webhooks\Events\PayoutFailed;
+use Mollie\Api\Webhooks\Events\PayoutInitiated;
+use Mollie\Api\Webhooks\Events\PayoutProcessingAtBank;
+use Mollie\Api\Webhooks\Events\SalesInvoiceCanceled;
+use Mollie\Api\Webhooks\Events\SalesInvoiceCreated;
+use Mollie\Api\Webhooks\Events\SalesInvoiceIssued;
+use Mollie\Api\Webhooks\Events\SalesInvoicePaid;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferExpired;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferMatched;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferReceived;
+use Mollie\Api\Webhooks\Events\UnmatchedCreditTransferReturned;
 use Mollie\Api\Webhooks\WebhookEventMapper;
 use Mollie\Api\Webhooks\WebhookSnapshotOrigin;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +81,90 @@ class WebhookEventMapperTest extends TestCase
             ],
             'balance-transaction.created' => [
                 BalanceTransactionCreated::class,
+            ],
+            'payout.initiated' => [
+                PayoutInitiated::class,
+            ],
+            'payout.processing-at-bank' => [
+                PayoutProcessingAtBank::class,
+            ],
+            'payout.completed' => [
+                PayoutCompleted::class,
+            ],
+            'payout.canceled' => [
+                PayoutCanceled::class,
+            ],
+            'payout.failed' => [
+                PayoutFailed::class,
+            ],
+            'business-account-transfer.requested' => [
+                BusinessAccountTransferRequested::class,
+            ],
+            'business-account-transfer.initiated' => [
+                BusinessAccountTransferInitiated::class,
+            ],
+            'business-account-transfer.pending-review' => [
+                BusinessAccountTransferPendingReview::class,
+            ],
+            'business-account-transfer.processed' => [
+                BusinessAccountTransferProcessed::class,
+            ],
+            'business-account-transfer.failed' => [
+                BusinessAccountTransferFailed::class,
+            ],
+            'business-account-transfer.blocked' => [
+                BusinessAccountTransferBlocked::class,
+            ],
+            'business-account-transfer.returned' => [
+                BusinessAccountTransferReturned::class,
+            ],
+            'connect-balance-transfer.succeeded' => [
+                ConnectBalanceTransferSucceeded::class,
+            ],
+            'connect-balance-transfer.failed' => [
+                ConnectBalanceTransferFailed::class,
+            ],
+            'sales-invoice.created' => [
+                SalesInvoiceCreated::class,
+            ],
+            'sales-invoice.issued' => [
+                SalesInvoiceIssued::class,
+            ],
+            'sales-invoice.canceled' => [
+                SalesInvoiceCanceled::class,
+            ],
+            'sales-invoice.paid' => [
+                SalesInvoicePaid::class,
+            ],
+            'dispute.created' => [
+                DisputeCreated::class,
+            ],
+            'dispute.resolved' => [
+                DisputeResolved::class,
+            ],
+            'dispute.updated' => [
+                DisputeUpdated::class,
+            ],
+            'file.accepted' => [
+                FileAccepted::class,
+            ],
+            'file.rejected' => [
+                FileRejected::class,
+            ],
+            'file.failed' => [
+                FileFailed::class,
+            ],
+            'unmatched-credit-transfer.received' => [
+                UnmatchedCreditTransferReceived::class,
+            ],
+            'unmatched-credit-transfer.matched' => [
+                UnmatchedCreditTransferMatched::class,
+            ],
+            'unmatched-credit-transfer.returned' => [
+                UnmatchedCreditTransferReturned::class,
+            ],
+            'unmatched-credit-transfer.expired' => [
+                UnmatchedCreditTransferExpired::class,
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- Add newly documented next-gen webhook event type constants for payout, business account transfer, dispute, file, and unmatched credit transfer events
- Register concrete webhook event handlers for those event types
- Add fake snapshot fixtures and mapper coverage for global and beta webhook events

## Verification
- ./vendor/bin/phpunit tests/Webhooks/WebhookEventMapperTest.php
- composer test