### PR TITLE
feat: re-add payouts endpoints (restored after revert)

### DIFF
--- a/src/EndpointCollection/PayoutEndpointCollection.php
+++ b/src/EndpointCollection/PayoutEndpointCollection.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Mollie\Api\EndpointCollection;
+
+use Mollie\Api\Exceptions\RequestException;
+use Mollie\Api\Factories\CreatePayoutRequestFactory;
+use Mollie\Api\Factories\SortablePaginatedQueryFactory;
+use Mollie\Api\Http\Requests\CancelPayoutRequest;
+use Mollie\Api\Http\Requests\GetPaginatedPayoutsRequest;
+use Mollie\Api\Http\Requests\GetPayoutRequest;
+use Mollie\Api\Resources\LazyCollection;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Resources\PayoutCollection;
+use Mollie\Api\Utils\Utility;
+
+class PayoutEndpointCollection extends EndpointCollection
+{
+    /**
+     * Creates a payout in Mollie.
+     *
+     * @param  array  $payload  An array containing details on the payout.
+     * @param  bool  $testmode  Set to true to create the payout in test mode.
+     *
+     * @throws RequestException
+     */
+    public function create(array $payload = [], bool $testmode = false): Payout
+    {
+        $testmode = Utility::extractBool($payload, 'testmode', $testmode);
+
+        $request = CreatePayoutRequestFactory::new()
+            ->withPayload($payload)
+            ->create();
+
+        /** @var Payout */
+        return $this->send($request->test($testmode));
+    }
+
+    /**
+     * Retrieve a payout from Mollie.
+     *
+     * Will throw an ApiException if the payout id is invalid or the resource cannot be found.
+     *
+     * @param  string  $id  The payout ID.
+     * @param  bool  $testmode  Set to true to retrieve the payout in test mode.
+     *
+     * @throws RequestException
+     */
+    public function get(string $id, bool $testmode = false): Payout
+    {
+        /** @var Payout */
+        return $this->send((new GetPayoutRequest($id))->test($testmode));
+    }
+
+    /**
+     * Cancel the given payout.
+     *
+     * Will throw an ApiException if the payout id is invalid, the resource cannot be found, or the payout can no longer be canceled.
+     *
+     * @param  string  $id  The payout ID.
+     * @param  bool  $testmode  Set to true to cancel the payout in test mode.
+     *
+     * @throws RequestException
+     */
+    public function cancel(string $id, bool $testmode = false): Payout
+    {
+        /** @var Payout */
+        return $this->send((new CancelPayoutRequest($id))->test($testmode));
+    }
+
+    /**
+     * Retrieves a collection of payouts from Mollie.
+     *
+     * @param  string|null  $from  The first payout ID you want to include in your list.
+     * @param  int|null  $limit  The maximum number of payouts to return.
+     * @param  array  $filters  An array of filters, such as "balanceId", "sort", and "testmode".
+     *
+     * @throws RequestException
+     */
+    public function page(?string $from = null, ?int $limit = null, array $filters = []): PayoutCollection
+    {
+        $testmode = Utility::extractBool($filters, 'testmode', false);
+
+        $query = SortablePaginatedQueryFactory::new()
+            ->withQuery([
+                'from' => $from,
+                'limit' => $limit,
+                'filters' => $filters,
+            ])
+            ->create();
+
+        $request = new GetPaginatedPayoutsRequest(
+            $query->from,
+            $query->limit,
+            $query->sort,
+            $filters['balanceId'] ?? null
+        );
+
+        /** @var PayoutCollection */
+        return $this->send($request->test($testmode));
+    }
+
+    /**
+     * Create an iterator for iterating over payouts retrieved from Mollie.
+     *
+     * @param  string|null  $from  The first payout ID you want to include in your list.
+     * @param  int|null  $limit  The maximum number of payouts to return per page.
+     * @param  array  $filters  An array of filters, such as "balanceId", "sort", and "testmode".
+     * @param  bool  $iterateBackwards  Set to true for reverse order iteration (default is false).
+     *
+     * @throws RequestException
+     */
+    public function iterator(?string $from = null, ?int $limit = null, array $filters = [], bool $iterateBackwards = false): LazyCollection
+    {
+        $testmode = Utility::extractBool($filters, 'testmode', false);
+
+        $query = SortablePaginatedQueryFactory::new()
+            ->withQuery([
+                'from' => $from,
+                'limit' => $limit,
+                'filters' => $filters,
+            ])
+            ->create();
+
+        $request = new GetPaginatedPayoutsRequest(
+            $query->from,
+            $query->limit,
+            $query->sort,
+            $filters['balanceId'] ?? null
+        );
+
+        return $this->send(
+            $request
+                ->useIterator()
+                ->setIterationDirection($iterateBackwards)
+                ->test($testmode)
+        );
+    }
+}

--- a/src/Factories/CreatePayoutRequestFactory.php
+++ b/src/Factories/CreatePayoutRequestFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mollie\Api\Factories;
+
+use Mollie\Api\Http\Requests\CreatePayoutRequest;
+
+class CreatePayoutRequestFactory extends RequestFactory
+{
+    public function create(): CreatePayoutRequest
+    {
+        return new CreatePayoutRequest(
+            $this->payload('balanceId'),
+            $this->transformFromPayload('amount', fn ($item) => MoneyFactory::new($item)->create()),
+            $this->payload('description')
+        );
+    }
+}

--- a/src/Fake/Responses/payout-list.json
+++ b/src/Fake/Responses/payout-list.json
@@ -1,0 +1,53 @@
+{
+  "count": 1,
+  "_embedded": {
+    "payouts": [
+      {
+        "resource": "payout",
+        "id": "po_4KgGJJSZpH",
+        "mode": "live",
+        "testmode": false,
+        "createdAt": "2026-05-19T10:30:54+00:00",
+        "balanceId": "bal_gVMhHKqSSRYJyPsuoPNFH",
+        "amount": {
+          "currency": "EUR",
+          "value": "100.00"
+        },
+        "description": "Scheduled payout",
+        "status": "requested",
+        "statusReason": {
+          "code": "requested",
+          "message": "The payout has been requested and will be executed on the next scheduled date."
+        },
+        "initiatedAt": null,
+        "completedAt": null,
+        "canceledAt": null,
+        "_links": {
+          "self": {
+            "href": "...",
+            "type": "application/hal+json"
+          },
+          "documentation": {
+            "href": "...",
+            "type": "text/html"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "documentation": {
+      "href": "...",
+      "type": "text/html"
+    },
+    "self": {
+      "href": "...",
+      "type": "application/hal+json"
+    },
+    "previous": null,
+    "next": {
+      "href": "https://api.mollie.com/v2/payouts?from=po_4KgGJJSZpH&limit=5",
+      "type": "application/hal+json"
+    }
+  }
+}

--- a/src/Fake/Responses/payout.json
+++ b/src/Fake/Responses/payout.json
@@ -1,12 +1,21 @@
 {
   "resource": "payout",
   "id": "{{ RESOURCE_ID }}",
+  "mode": "live",
+  "balanceId": "bal_gVMhHKqSSRYJyPsuoPNFH",
   "amount": {
     "currency": "EUR",
     "value": "100.00"
   },
-  "status": "completed",
-  "description": "Payout",
+  "description": "Scheduled payout",
+  "status": "requested",
+  "statusReason": {
+    "code": "requested",
+    "message": "The payout has been requested and will be executed on the next scheduled date."
+  },
+  "initiatedAt": null,
+  "completedAt": null,
+  "canceledAt": null,
   "createdAt": "2023-12-25T10:30:54+00:00",
   "_links": {
     "self": {

--- a/src/Http/Requests/CancelPayoutRequest.php
+++ b/src/Http/Requests/CancelPayoutRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\SupportsTestmodeInQuery;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Types\Method;
+
+class CancelPayoutRequest extends ResourceHydratableRequest implements SupportsTestmodeInQuery
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected static string $method = Method::DELETE;
+
+    /**
+     * The resource class the request should be casted to.
+     */
+    protected $hydratableResource = Payout::class;
+
+    private string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * The resource path.
+     */
+    public function resolveResourcePath(): string
+    {
+        return "payouts/{$this->id}";
+    }
+}

--- a/src/Http/Requests/CreatePayoutRequest.php
+++ b/src/Http/Requests/CreatePayoutRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\HasPayload;
+use Mollie\Api\Contracts\SupportsTestmodeInPayload;
+use Mollie\Api\Http\Data\Money;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Traits\HasJsonPayload;
+use Mollie\Api\Types\Method;
+
+class CreatePayoutRequest extends ResourceHydratableRequest implements HasPayload, SupportsTestmodeInPayload
+{
+    use HasJsonPayload;
+
+    /**
+     * Define the HTTP method.
+     */
+    protected static string $method = Method::POST;
+
+    /**
+     * The resource class the request should be casted to.
+     */
+    protected $hydratableResource = Payout::class;
+
+    private string $balanceId;
+
+    private ?Money $amount;
+
+    private ?string $description;
+
+    public function __construct(
+        string $balanceId,
+        ?Money $amount = null,
+        ?string $description = null
+    ) {
+        $this->balanceId = $balanceId;
+        $this->amount = $amount;
+        $this->description = $description;
+    }
+
+    protected function defaultPayload(): array
+    {
+        return [
+            'balanceId' => $this->balanceId,
+            'amount' => $this->amount,
+            'description' => $this->description,
+        ];
+    }
+
+    /**
+     * The resource path.
+     */
+    public function resolveResourcePath(): string
+    {
+        return 'payouts';
+    }
+}

--- a/src/Http/Requests/GetPaginatedPayoutsRequest.php
+++ b/src/Http/Requests/GetPaginatedPayoutsRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\IsIteratable;
+use Mollie\Api\Contracts\SupportsTestmodeInQuery;
+use Mollie\Api\Resources\PayoutCollection;
+use Mollie\Api\Traits\IsIteratableRequest;
+
+class GetPaginatedPayoutsRequest extends SortablePaginatedRequest implements IsIteratable, SupportsTestmodeInQuery
+{
+    use IsIteratableRequest;
+
+    /**
+     * The resource class the request should be casted to.
+     */
+    protected $hydratableResource = PayoutCollection::class;
+
+    public function __construct(
+        ?string $from = null,
+        ?int $limit = null,
+        ?string $sort = null,
+        ?string $balanceId = null
+    ) {
+        parent::__construct($from, $limit, $sort);
+
+        $this->query()->add('balanceId', $balanceId);
+    }
+
+    /**
+     * The resource path.
+     */
+    public function resolveResourcePath(): string
+    {
+        return 'payouts';
+    }
+}

--- a/src/Http/Requests/GetPayoutRequest.php
+++ b/src/Http/Requests/GetPayoutRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\SupportsTestmodeInQuery;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Types\Method;
+
+class GetPayoutRequest extends ResourceHydratableRequest implements SupportsTestmodeInQuery
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected static string $method = Method::GET;
+
+    /**
+     * The resource class the request should be casted to.
+     */
+    protected $hydratableResource = Payout::class;
+
+    private string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * The resource path.
+     */
+    public function resolveResourcePath(): string
+    {
+        return "payouts/{$this->id}";
+    }
+}

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -30,6 +30,7 @@ use Mollie\Api\EndpointCollection\PaymentLinkEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentLinkPaymentEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentRefundEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentRouteEndpointCollection;
+use Mollie\Api\EndpointCollection\PayoutEndpointCollection;
 use Mollie\Api\EndpointCollection\PermissionEndpointCollection;
 use Mollie\Api\EndpointCollection\ProfileEndpointCollection;
 use Mollie\Api\EndpointCollection\ProfileMethodEndpointCollection;
@@ -94,6 +95,7 @@ use Mollie\Api\Utils\Url;
  * @property PaymentRefundEndpointCollection $paymentRefunds
  * @property PaymentRouteEndpointCollection $paymentRoutes
  * @property PermissionEndpointCollection $permissions
+ * @property PayoutEndpointCollection $payouts
  * @property ProfileEndpointCollection $profiles
  * @property ProfileMethodEndpointCollection $profileMethods
  * @property RefundEndpointCollection $refunds

--- a/src/Resources/Payout.php
+++ b/src/Resources/Payout.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Mollie\Api\Resources;
+
+/**
+ * @property \Mollie\Api\MollieApiClient $connector
+ */
+class Payout extends BaseResource
+{
+    /**
+     * The identifier uniquely referring to this payout.
+     *
+     * @example po_4KgGJJSZpH
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * Mode of the payout, either "live" or "test" depending on the API key that was used.
+     *
+     * @var string
+     */
+    public $mode;
+
+    /**
+     * Whether this payout was created in test mode.
+     *
+     * @var bool
+     */
+    public $testmode;
+
+    /**
+     * The identifier of the balance that will be paid out.
+     *
+     * @example bal_gVMhHKqSSRYJyPsuoPNFH
+     *
+     * @var string
+     */
+    public $balanceId;
+
+    /**
+     * The amount paid out, excluding any applicable fees.
+     *
+     * @var \stdClass|null
+     */
+    public $amount;
+
+    /**
+     * The description that will appear on the bank statement for this payout.
+     *
+     * @var string|null
+     */
+    public $description;
+
+    /**
+     * The status of the payout.
+     * Possible values: "requested", "initiated", "processing-at-bank", "completed", "canceled", "failed"
+     *
+     * @var string
+     */
+    public $status;
+
+    /**
+     * The reason for the status of the payout.
+     *
+     * @var object|null
+     */
+    public $statusReason;
+
+    /**
+     * UTC datetime the payout was created in ISO-8601 format.
+     *
+     * @example "2026-05-19T10:30:54+00:00"
+     *
+     * @var string
+     */
+    public $createdAt;
+
+    /**
+     * UTC datetime the payout was initiated in ISO-8601 format.
+     *
+     * @example "2026-05-19T10:30:54+00:00"
+     *
+     * @var string|null
+     */
+    public $initiatedAt;
+
+    /**
+     * UTC datetime the payout was completed in ISO-8601 format.
+     *
+     * @example "2026-05-19T10:30:54+00:00"
+     *
+     * @var string|null
+     */
+    public $completedAt;
+
+    /**
+     * UTC datetime the payout was canceled in ISO-8601 format.
+     *
+     * @example "2026-05-19T10:30:54+00:00"
+     *
+     * @var string|null
+     */
+    public $canceledAt;
+
+    /**
+     * @var \stdClass
+     */
+    public $_links;
+}

--- a/src/Resources/PayoutCollection.php
+++ b/src/Resources/PayoutCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mollie\Api\Resources;
+
+class PayoutCollection extends CursorCollection
+{
+    /**
+     * The name of the collection resource in Mollie's API.
+     */
+    public static string $collectionName = 'payouts';
+
+    /**
+     * Resource class name.
+     */
+    public static string $resource = Payout::class;
+}

--- a/src/Resources/ResourceRegistry.php
+++ b/src/Resources/ResourceRegistry.php
@@ -146,6 +146,7 @@ class ResourceRegistry
             Payment::class => 'payments',
             PaymentLink::class => 'payment-links',
             Permission::class => 'permissions',
+            Payout::class => 'payouts',
             Profile::class => 'profiles',
             Refund::class => 'refunds',
             Route::class => 'routes',

--- a/src/Traits/HasEndpoints.php
+++ b/src/Traits/HasEndpoints.php
@@ -26,6 +26,7 @@ use Mollie\Api\EndpointCollection\PaymentLinkEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentLinkPaymentEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentRefundEndpointCollection;
 use Mollie\Api\EndpointCollection\PaymentRouteEndpointCollection;
+use Mollie\Api\EndpointCollection\PayoutEndpointCollection;
 use Mollie\Api\EndpointCollection\PermissionEndpointCollection;
 use Mollie\Api\EndpointCollection\ProfileEndpointCollection;
 use Mollie\Api\EndpointCollection\ProfileMethodEndpointCollection;
@@ -86,6 +87,7 @@ trait HasEndpoints
             'paymentLinkPayments' => PaymentLinkPaymentEndpointCollection::class,
             'paymentRoutes' => PaymentRouteEndpointCollection::class,
             'permissions' => PermissionEndpointCollection::class,
+            'payouts' => PayoutEndpointCollection::class,
             'profiles' => ProfileEndpointCollection::class,
             'profileMethods' => ProfileMethodEndpointCollection::class,
             'refunds' => RefundEndpointCollection::class,

--- a/tests/EndpointCollection/PayoutEndpointCollectionTest.php
+++ b/tests/EndpointCollection/PayoutEndpointCollectionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\EndpointCollection;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\CancelPayoutRequest;
+use Mollie\Api\Http\Requests\CreatePayoutRequest;
+use Mollie\Api\Http\Requests\DynamicGetRequest;
+use Mollie\Api\Http\Requests\GetPaginatedPayoutsRequest;
+use Mollie\Api\Http\Requests\GetPayoutRequest;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Resources\PayoutCollection;
+use PHPUnit\Framework\TestCase;
+
+class PayoutEndpointCollectionTest extends TestCase
+{
+    /** @test */
+    public function page()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedPayoutsRequest::class => MockResponse::ok('payout-list'),
+        ]);
+
+        /** @var PayoutCollection $payouts */
+        $payouts = $client->payouts->page();
+
+        $this->assertInstanceOf(PayoutCollection::class, $payouts);
+        $this->assertGreaterThan(0, $payouts->count());
+        $this->assertGreaterThan(0, count($payouts));
+    }
+
+    /** @test */
+    public function iterator()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedPayoutsRequest::class => MockResponse::ok('payout-list'),
+            DynamicGetRequest::class => MockResponse::ok('empty-list', 'payouts'),
+        ]);
+
+        foreach ($client->payouts->iterator() as $payout) {
+            $this->assertPayout($payout);
+        }
+    }
+
+    /** @test */
+    public function create()
+    {
+        $client = new MockMollieClient([
+            CreatePayoutRequest::class => MockResponse::created('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        /** @var Payout $payout */
+        $payout = $client->payouts->create([
+            'balanceId' => 'bal_gVMhHKqSSRYJyPsuoPNFH',
+            'amount' => [
+                'currency' => 'EUR',
+                'value' => '100.00',
+            ],
+            'description' => 'Scheduled payout',
+        ]);
+
+        $this->assertPayout($payout);
+    }
+
+    /** @test */
+    public function get()
+    {
+        $client = new MockMollieClient([
+            GetPayoutRequest::class => MockResponse::ok('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        /** @var Payout $payout */
+        $payout = $client->payouts->get('po_4KgGJJSZpH');
+
+        $this->assertPayout($payout);
+    }
+
+    /** @test */
+    public function cancel()
+    {
+        $client = new MockMollieClient([
+            CancelPayoutRequest::class => MockResponse::ok('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        /** @var Payout $payout */
+        $payout = $client->payouts->cancel('po_4KgGJJSZpH');
+
+        $this->assertPayout($payout);
+    }
+
+    private function assertPayout(Payout $payout): void
+    {
+        $this->assertInstanceOf(Payout::class, $payout);
+    }
+}

--- a/tests/Factories/CreatePayoutRequestFactoryTest.php
+++ b/tests/Factories/CreatePayoutRequestFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Factories;
+
+use Mollie\Api\Factories\CreatePayoutRequestFactory;
+use Mollie\Api\Http\Requests\CreatePayoutRequest;
+use PHPUnit\Framework\TestCase;
+
+class CreatePayoutRequestFactoryTest extends TestCase
+{
+    /** @test */
+    public function create_returns_create_payout_request_object()
+    {
+        $factory = CreatePayoutRequestFactory::new()
+            ->withPayload([
+                'balanceId' => 'bal_gVMhHKqSSRYJyPsuoPNFH',
+                'amount' => [
+                    'currency' => 'EUR',
+                    'value' => '100.00',
+                ],
+                'description' => 'Scheduled payout',
+            ]);
+
+        $this->assertInstanceOf(CreatePayoutRequest::class, $factory->create());
+    }
+}

--- a/tests/Http/Requests/CancelPayoutRequestTest.php
+++ b/tests/Http/Requests/CancelPayoutRequestTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\CancelPayoutRequest;
+use Mollie\Api\Resources\Payout;
+use PHPUnit\Framework\TestCase;
+
+class CancelPayoutRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_cancel_payout()
+    {
+        $client = new MockMollieClient([
+            CancelPayoutRequest::class => MockResponse::ok('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        $request = new CancelPayoutRequest('po_4KgGJJSZpH');
+
+        /** @var Payout */
+        $payout = $client->send($request);
+
+        $this->assertTrue($payout->getResponse()->successful());
+        $this->assertInstanceOf(Payout::class, $payout);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $payoutId = 'po_4KgGJJSZpH';
+        $request = new CancelPayoutRequest($payoutId);
+
+        $this->assertEquals(
+            "payouts/{$payoutId}",
+            $request->resolveResourcePath()
+        );
+    }
+}

--- a/tests/Http/Requests/CreatePayoutRequestTest.php
+++ b/tests/Http/Requests/CreatePayoutRequestTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Data\Money;
+use Mollie\Api\Http\PendingRequest;
+use Mollie\Api\Http\Requests\CreatePayoutRequest;
+use Mollie\Api\Resources\Payout;
+use PHPUnit\Framework\TestCase;
+
+class CreatePayoutRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_payout()
+    {
+        $client = new MockMollieClient([
+            CreatePayoutRequest::class => MockResponse::created('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        $request = new CreatePayoutRequest(
+            'bal_gVMhHKqSSRYJyPsuoPNFH',
+            new Money('EUR', '100.00'),
+            'Scheduled payout'
+        );
+
+        /** @var Payout */
+        $payout = $client->send($request);
+
+        $this->assertTrue($payout->getResponse()->successful());
+        $this->assertInstanceOf(Payout::class, $payout);
+    }
+
+    /** @test */
+    public function it_can_create_payout_without_amount()
+    {
+        $client = MockMollieClient::fake([
+            CreatePayoutRequest::class => MockResponse::created('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        $client->payouts->create([
+            'balanceId' => 'bal_gVMhHKqSSRYJyPsuoPNFH',
+            'description' => 'Scheduled payout',
+        ]);
+
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $payload = json_decode((string) $pendingRequest->createPsrRequest()->getBody(), true);
+
+            $this->assertSame('bal_gVMhHKqSSRYJyPsuoPNFH', $payload['balanceId']);
+            $this->assertArrayNotHasKey('amount', $payload);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_sends_testmode_in_the_payload()
+    {
+        $client = MockMollieClient::fake([
+            CreatePayoutRequest::class => MockResponse::created('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        $client->payouts->create([
+            'balanceId' => 'bal_gVMhHKqSSRYJyPsuoPNFH',
+            'testmode' => true,
+        ]);
+
+        $client->assertSent(function (PendingRequest $pendingRequest) {
+            $payload = json_decode((string) $pendingRequest->createPsrRequest()->getBody(), true);
+
+            $this->assertTrue($payload['testmode']);
+            $this->assertFalse($pendingRequest->query()->has('testmode'));
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new CreatePayoutRequest('bal_gVMhHKqSSRYJyPsuoPNFH');
+
+        $this->assertEquals('payouts', $request->resolveResourcePath());
+    }
+}

--- a/tests/Http/Requests/GetPaginatedPayoutsRequestTest.php
+++ b/tests/Http/Requests/GetPaginatedPayoutsRequestTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Fake\SequenceMockResponse;
+use Mollie\Api\Http\Requests\DynamicGetRequest;
+use Mollie\Api\Http\Requests\GetPaginatedPayoutsRequest;
+use Mollie\Api\Resources\Payout;
+use Mollie\Api\Resources\PayoutCollection;
+use PHPUnit\Framework\TestCase;
+
+class GetPaginatedPayoutsRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_list_payouts()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedPayoutsRequest::class => MockResponse::ok('payout-list'),
+        ]);
+
+        $request = new GetPaginatedPayoutsRequest;
+
+        /** @var PayoutCollection */
+        $payouts = $client->send($request);
+
+        $this->assertTrue($payouts->getResponse()->successful());
+
+        foreach ($payouts as $payout) {
+            $this->assertInstanceOf(Payout::class, $payout);
+            $this->assertEquals('payout', $payout->resource);
+        }
+    }
+
+    /** @test */
+    public function it_can_iterate_over_payouts()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedPayoutsRequest::class => MockResponse::ok('payout-list'),
+            DynamicGetRequest::class => new SequenceMockResponse(
+                MockResponse::ok('payout-list'),
+                MockResponse::ok('empty-list', 'payouts'),
+            ),
+        ]);
+
+        $request = (new GetPaginatedPayoutsRequest)->useIterator();
+
+        /** @var PayoutCollection */
+        $payouts = $client->send($request);
+        $this->assertTrue($payouts->getResponse()->successful());
+
+        foreach ($payouts as $payout) {
+            $this->assertInstanceOf(Payout::class, $payout);
+        }
+
+        $client->assertSentCount(3);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new GetPaginatedPayoutsRequest;
+
+        $this->assertEquals('payouts', $request->resolveResourcePath());
+    }
+}

--- a/tests/Http/Requests/GetPayoutRequestTest.php
+++ b/tests/Http/Requests/GetPayoutRequestTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\GetPayoutRequest;
+use Mollie\Api\Resources\Payout;
+use PHPUnit\Framework\TestCase;
+
+class GetPayoutRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_get_payout()
+    {
+        $client = new MockMollieClient([
+            GetPayoutRequest::class => MockResponse::ok('payout', 'po_4KgGJJSZpH'),
+        ]);
+
+        $request = new GetPayoutRequest('po_4KgGJJSZpH');
+
+        /** @var Payout */
+        $payout = $client->send($request);
+
+        $this->assertTrue($payout->getResponse()->successful());
+        $this->assertInstanceOf(Payout::class, $payout);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $payoutId = 'po_4KgGJJSZpH';
+        $request = new GetPayoutRequest($payoutId);
+
+        $this->assertEquals(
+            "payouts/{$payoutId}",
+            $request->resolveResourcePath()
+        );
+    }
+}

--- a/tests/MollieApiClientTest.php
+++ b/tests/MollieApiClientTest.php
@@ -92,6 +92,7 @@ class MollieApiClientTest extends TestCase
 
         $this->assertNotEmpty($client_copy->customerPayments);
         $this->assertNotEmpty($client_copy->payments);
+        $this->assertNotEmpty($client_copy->payouts);
         $this->assertNotEmpty($client_copy->methods);
     }
 

--- a/tests/Resources/ResourceRegistryTest.php
+++ b/tests/Resources/ResourceRegistryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Resources;
 
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Resources\PaymentLink;
+use Mollie\Api\Resources\Payout;
 use Mollie\Api\Resources\ResourceRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -16,6 +17,8 @@ class ResourceRegistryTest extends TestCase
 
         $this->assertSame(Payment::class, $registry->for('payment'));
         $this->assertSame(Payment::class, $registry->for('payments'));
+        $this->assertSame(Payout::class, $registry->for('payout'));
+        $this->assertSame(Payout::class, $registry->for('payouts'));
 
         // underscore input gets normalized to kebab internally
         $this->assertSame(PaymentLink::class, $registry->for('payment_link'));


### PR DESCRIPTION
Restores the payouts endpoints feature that was merged in #890 and reverted in #892.

This is a revert-of-revert: identical content to #890, applied as a single commit on top of current main.

Re-opening for a proper review pass.

## What this restores
- Payouts endpoint collection
- Payout resource fields aligned with OpenAPI spec
- Testmode preserved in create payout payload
- Coding-style fixes

## Original PR
Closes the gap left by #892 (revert).
See #890 for the original review thread.