### PR TITLE
feat: add terminal pairing code endpoints

### DIFF
--- a/docs/endpoint-collections.md
+++ b/docs/endpoint-collections.md
@@ -620,6 +620,42 @@ $terminal = $mollie->terminals->get('terminalId');
 $terminals = $mollie->terminals->page();
 ```
 
+## Terminal Pairing Codes
+
+Official Documentation:
+[Request pairing code](https://docs.mollie.com/reference/terminals-request-pairing-code),
+[Get pairing code](https://docs.mollie.com/reference/terminals-get-pairing-code),
+[List pairing codes](https://docs.mollie.com/reference/terminals-list-pairing-codes),
+[Revoke pairing code](https://docs.mollie.com/reference/terminals-revoke-pairing-code)
+
+### Terminal Pairing Code Management
+
+```php
+// Request a pairing code, including QR code details
+$pairingCode = $mollie->terminalPairingCodes->request('profileId', includeQrCode: true);
+
+// Get a pairing code, including QR code details
+$pairingCode = $mollie->terminalPairingCodes->get('pairingCodeId', includeQrCode: true);
+
+// List pairing codes
+$pairingCodes = $mollie->terminalPairingCodes->page(limit: 50, profileId: 'profileId');
+
+// Use iterator
+foreach ($mollie->terminalPairingCodes->iterator(profileId: 'profileId') as $pairingCode) {
+    echo $pairingCode->id;
+}
+
+// Revoke a pairing code
+$pairingCode = $mollie->terminalPairingCodes->revoke('pairingCodeId');
+
+// Check pairing code status using helper methods
+if ($pairingCode->isActive()) {
+    echo "Pairing code is active\n";
+} elseif ($pairingCode->isRevoked()) {
+    echo "Pairing code was revoked at: {$pairingCode->revokedAt}\n";
+}
+```
+
 ## Wallets
 
 [Official Documentation](https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session)

--- a/src/EndpointCollection/TerminalPairingCodeEndpointCollection.php
+++ b/src/EndpointCollection/TerminalPairingCodeEndpointCollection.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Mollie\Api\EndpointCollection;
+
+use Mollie\Api\Exceptions\RequestException;
+use Mollie\Api\Http\Requests\GetPaginatedTerminalPairingCodesRequest;
+use Mollie\Api\Http\Requests\GetTerminalPairingCodeRequest;
+use Mollie\Api\Http\Requests\RequestTerminalPairingCodeRequest;
+use Mollie\Api\Http\Requests\RevokeTerminalPairingCodeRequest;
+use Mollie\Api\Resources\LazyCollection;
+use Mollie\Api\Resources\TerminalPairingCode;
+use Mollie\Api\Resources\TerminalPairingCodeCollection;
+
+class TerminalPairingCodeEndpointCollection extends EndpointCollection
+{
+    /**
+     * Request a new pairing code to onboard a point-of-sale terminal.
+     *
+     * @throws RequestException
+     */
+    public function request(string $profileId, bool $includeQrCode = false): TerminalPairingCode
+    {
+        /** @var TerminalPairingCode */
+        return $this->send(new RequestTerminalPairingCodeRequest($profileId, $includeQrCode));
+    }
+
+    /**
+     * Retrieve a terminal pairing code from Mollie.
+     *
+     * Will throw an ApiException if the pairing code ID is invalid or the resource cannot be found.
+     *
+     * @throws RequestException
+     */
+    public function get(string $id, bool $includeQrCode = false): TerminalPairingCode
+    {
+        /** @var TerminalPairingCode */
+        return $this->send(new GetTerminalPairingCodeRequest($id, $includeQrCode));
+    }
+
+    /**
+     * Retrieve a collection of terminal pairing codes from Mollie, ordered from newest to oldest.
+     *
+     * @param  string|null  $from  The first pairing code ID you want to include in your list.
+     *
+     * @throws RequestException
+     */
+    public function page(
+        ?string $from = null,
+        ?int $limit = null,
+        ?string $profileId = null,
+        ?string $sort = null
+    ): TerminalPairingCodeCollection {
+        /** @var TerminalPairingCodeCollection */
+        return $this->send(new GetPaginatedTerminalPairingCodesRequest($from, $limit, $profileId, $sort));
+    }
+
+    /**
+     * Revoke a terminal pairing code, preventing onboarding of new terminals.
+     *
+     * Terminals that have already paired with this code are not affected.
+     *
+     * Will throw an ApiException if the pairing code ID is invalid or the resource cannot be found.
+     *
+     * @throws RequestException
+     */
+    public function revoke(string $id): TerminalPairingCode
+    {
+        /** @var TerminalPairingCode */
+        return $this->send(new RevokeTerminalPairingCodeRequest($id));
+    }
+
+    /**
+     * Create an iterator for iterating over terminal pairing codes retrieved from Mollie.
+     *
+     * @param  string|null  $from  The first resource ID you want to include in your list.
+     * @param  bool  $iterateBackwards  Set to true for reverse order iteration (default is false).
+     */
+    public function iterator(
+        ?string $from = null,
+        ?int $limit = null,
+        ?string $profileId = null,
+        ?string $sort = null,
+        bool $iterateBackwards = false
+    ): LazyCollection {
+        return $this->send(
+            (new GetPaginatedTerminalPairingCodesRequest($from, $limit, $profileId, $sort))
+                ->useIterator()
+                ->setIterationDirection($iterateBackwards)
+        );
+    }
+}

--- a/src/EndpointCollection/TerminalPairingCodeEndpointCollection.php
+++ b/src/EndpointCollection/TerminalPairingCodeEndpointCollection.php
@@ -47,11 +47,11 @@ class TerminalPairingCodeEndpointCollection extends EndpointCollection
     public function page(
         ?string $from = null,
         ?int $limit = null,
-        ?string $profileId = null,
-        ?string $sort = null
+        ?string $sort = null,
+        ?string $profileId = null
     ): TerminalPairingCodeCollection {
         /** @var TerminalPairingCodeCollection */
-        return $this->send(new GetPaginatedTerminalPairingCodesRequest($from, $limit, $profileId, $sort));
+        return $this->send(new GetPaginatedTerminalPairingCodesRequest($from, $limit, $sort, $profileId));
     }
 
     /**
@@ -78,12 +78,12 @@ class TerminalPairingCodeEndpointCollection extends EndpointCollection
     public function iterator(
         ?string $from = null,
         ?int $limit = null,
-        ?string $profileId = null,
         ?string $sort = null,
+        ?string $profileId = null,
         bool $iterateBackwards = false
     ): LazyCollection {
         return $this->send(
-            (new GetPaginatedTerminalPairingCodesRequest($from, $limit, $profileId, $sort))
+            (new GetPaginatedTerminalPairingCodesRequest($from, $limit, $sort, $profileId))
                 ->useIterator()
                 ->setIterationDirection($iterateBackwards)
         );

--- a/src/Fake/Responses/terminal-pairing-code-list.json
+++ b/src/Fake/Responses/terminal-pairing-code-list.json
@@ -1,0 +1,69 @@
+{
+  "count": 2,
+  "_embedded": {
+    "terminal-pairing-codes": [
+      {
+        "resource": "terminal-pairing-code",
+        "id": "termpc_R7gX5Ea9bC4DkFj3G",
+        "mode": "live",
+        "code": "20eb5ca1f78b48ae9e2b",
+        "profileId": "pfl_jA9bC4DkFj3G",
+        "status": "active",
+        "expiresAt": "2026-03-10T10:00:00+00:00",
+        "revokedAt": null,
+        "createdAt": "2025-12-10T10:00:00+00:00",
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G",
+            "type": "application/hal+json"
+          },
+          "profile": {
+            "href": "https://api.mollie.com/v2/profiles/pfl_jA9bC4DkFj3G",
+            "type": "application/hal+json"
+          },
+          "documentation": {
+            "href": "https://docs.mollie.com/reference/terminals-get-pairing-code",
+            "type": "text/html"
+          }
+        }
+      },
+      {
+        "resource": "terminal-pairing-code",
+        "id": "termpc_H5nR2Lp8qM6vBcXe",
+        "mode": "live",
+        "code": "3d7e1a4f8b2c905f6a4c",
+        "profileId": "pfl_jA9bC4DkFj3G",
+        "status": "revoked",
+        "expiresAt": "2026-01-08T10:00:00+00:00",
+        "revokedAt": "2025-11-15T08:30:00+00:00",
+        "createdAt": "2025-10-10T10:00:00+00:00",
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/terminals/pairing-codes/termpc_H5nR2Lp8qM6vBcXe",
+            "type": "application/hal+json"
+          },
+          "profile": {
+            "href": "https://api.mollie.com/v2/profiles/pfl_jA9bC4DkFj3G",
+            "type": "application/hal+json"
+          },
+          "documentation": {
+            "href": "https://docs.mollie.com/reference/terminals-get-pairing-code",
+            "type": "text/html"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/terminals/pairing-codes",
+      "type": "application/hal+json"
+    },
+    "previous": null,
+    "next": null,
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/terminals-list-pairing-codes",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/terminal-pairing-code-revoked.json
+++ b/src/Fake/Responses/terminal-pairing-code-revoked.json
@@ -1,0 +1,25 @@
+{
+  "resource": "terminal-pairing-code",
+  "id": "termpc_R7gX5Ea9bC4DkFj3G",
+  "mode": "live",
+  "code": "20eb5ca1f78b48ae9e2b",
+  "profileId": "pfl_jA9bC4DkFj3G",
+  "status": "revoked",
+  "expiresAt": "2026-03-10T10:00:00+00:00",
+  "revokedAt": "2026-01-15T09:30:00+00:00",
+  "createdAt": "2025-12-10T10:00:00+00:00",
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "profile": {
+      "href": "https://api.mollie.com/v2/profiles/pfl_jA9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/terminals-get-pairing-code",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/terminal-pairing-code-with-qr.json
+++ b/src/Fake/Responses/terminal-pairing-code-with-qr.json
@@ -1,0 +1,32 @@
+{
+  "resource": "terminal-pairing-code",
+  "id": "termpc_R7gX5Ea9bC4DkFj3G",
+  "mode": "live",
+  "code": "20eb5ca1f78b48ae9e2b",
+  "profileId": "pfl_jA9bC4DkFj3G",
+  "status": "active",
+  "expiresAt": "2026-03-10T10:00:00+00:00",
+  "revokedAt": null,
+  "createdAt": "2025-12-10T10:00:00+00:00",
+  "details": {
+    "qrCode": {
+      "height": 180,
+      "width": 180,
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxODAiIGhlaWdodD0iMTgwIj48L3N2Zz4="
+    }
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "profile": {
+      "href": "https://api.mollie.com/v2/profiles/pfl_jA9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/terminals-get-pairing-code",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Fake/Responses/terminal-pairing-code.json
+++ b/src/Fake/Responses/terminal-pairing-code.json
@@ -1,0 +1,25 @@
+{
+  "resource": "terminal-pairing-code",
+  "id": "termpc_R7gX5Ea9bC4DkFj3G",
+  "mode": "live",
+  "code": "20eb5ca1f78b48ae9e2b",
+  "profileId": "pfl_jA9bC4DkFj3G",
+  "status": "active",
+  "expiresAt": "2026-03-10T10:00:00+00:00",
+  "revokedAt": null,
+  "createdAt": "2025-12-10T10:00:00+00:00",
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "profile": {
+      "href": "https://api.mollie.com/v2/profiles/pfl_jA9bC4DkFj3G",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/terminals-get-pairing-code",
+      "type": "text/html"
+    }
+  }
+}

--- a/src/Http/Requests/GetPaginatedTerminalPairingCodesRequest.php
+++ b/src/Http/Requests/GetPaginatedTerminalPairingCodesRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\IsIteratable;
+use Mollie\Api\Resources\TerminalPairingCodeCollection;
+use Mollie\Api\Traits\IsIteratableRequest;
+
+/**
+ * @see https://docs.mollie.com/reference/terminals-list-pairing-codes
+ */
+class GetPaginatedTerminalPairingCodesRequest extends SortablePaginatedRequest implements IsIteratable
+{
+    use IsIteratableRequest;
+
+    protected $hydratableResource = TerminalPairingCodeCollection::class;
+
+    private ?string $profileId;
+
+    public function __construct(
+        ?string $from = null,
+        ?int $limit = null,
+        ?string $profileId = null,
+        ?string $sort = null
+    ) {
+        parent::__construct($from, $limit, $sort);
+
+        $this->profileId = $profileId;
+
+        $this->query()->add('profileId', $this->profileId);
+    }
+
+    public function resolveResourcePath(): string
+    {
+        return 'terminals/pairing-codes';
+    }
+}

--- a/src/Http/Requests/GetPaginatedTerminalPairingCodesRequest.php
+++ b/src/Http/Requests/GetPaginatedTerminalPairingCodesRequest.php
@@ -20,8 +20,8 @@ class GetPaginatedTerminalPairingCodesRequest extends SortablePaginatedRequest i
     public function __construct(
         ?string $from = null,
         ?int $limit = null,
-        ?string $profileId = null,
-        ?string $sort = null
+        ?string $sort = null,
+        ?string $profileId = null
     ) {
         parent::__construct($from, $limit, $sort);
 

--- a/src/Http/Requests/GetTerminalPairingCodeRequest.php
+++ b/src/Http/Requests/GetTerminalPairingCodeRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Resources\TerminalPairingCode;
+use Mollie\Api\Types\Method;
+
+/**
+ * @see https://docs.mollie.com/reference/terminals-get-pairing-code
+ */
+class GetTerminalPairingCodeRequest extends ResourceHydratableRequest
+{
+    protected static string $method = Method::GET;
+
+    protected $hydratableResource = TerminalPairingCode::class;
+
+    private string $id;
+
+    private bool $includeQrCode;
+
+    public function __construct(string $id, bool $includeQrCode = false)
+    {
+        $this->id = $id;
+        $this->includeQrCode = $includeQrCode;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return [
+            'include' => $this->includeQrCode ? 'details.qrCode' : null,
+        ];
+    }
+
+    public function resolveResourcePath(): string
+    {
+        return "terminals/pairing-codes/{$this->id}";
+    }
+}

--- a/src/Http/Requests/GetTerminalPairingCodeRequest.php
+++ b/src/Http/Requests/GetTerminalPairingCodeRequest.php
@@ -4,6 +4,7 @@ namespace Mollie\Api\Http\Requests;
 
 use Mollie\Api\Resources\TerminalPairingCode;
 use Mollie\Api\Types\Method;
+use Mollie\Api\Types\TerminalPairingCodeQuery;
 
 /**
  * @see https://docs.mollie.com/reference/terminals-get-pairing-code
@@ -27,7 +28,7 @@ class GetTerminalPairingCodeRequest extends ResourceHydratableRequest
     protected function defaultQuery(): array
     {
         return [
-            'include' => $this->includeQrCode ? 'details.qrCode' : null,
+            'include' => $this->includeQrCode ? TerminalPairingCodeQuery::INCLUDE_QR_CODE : null,
         ];
     }
 

--- a/src/Http/Requests/RequestTerminalPairingCodeRequest.php
+++ b/src/Http/Requests/RequestTerminalPairingCodeRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Contracts\HasPayload;
+use Mollie\Api\Resources\TerminalPairingCode;
+use Mollie\Api\Traits\HasJsonPayload;
+use Mollie\Api\Types\Method;
+
+/**
+ * @see https://docs.mollie.com/reference/terminals-request-pairing-code
+ */
+class RequestTerminalPairingCodeRequest extends ResourceHydratableRequest implements HasPayload
+{
+    use HasJsonPayload;
+
+    protected static string $method = Method::POST;
+
+    protected $hydratableResource = TerminalPairingCode::class;
+
+    private string $profileId;
+
+    private bool $includeQrCode;
+
+    public function __construct(string $profileId, bool $includeQrCode = false)
+    {
+        $this->profileId = $profileId;
+        $this->includeQrCode = $includeQrCode;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return [
+            'include' => $this->includeQrCode ? 'details.qrCode' : null,
+        ];
+    }
+
+    protected function defaultPayload(): array
+    {
+        return [
+            'profileId' => $this->profileId,
+        ];
+    }
+
+    public function resolveResourcePath(): string
+    {
+        return 'terminals/pairing-codes';
+    }
+}

--- a/src/Http/Requests/RequestTerminalPairingCodeRequest.php
+++ b/src/Http/Requests/RequestTerminalPairingCodeRequest.php
@@ -6,6 +6,7 @@ use Mollie\Api\Contracts\HasPayload;
 use Mollie\Api\Resources\TerminalPairingCode;
 use Mollie\Api\Traits\HasJsonPayload;
 use Mollie\Api\Types\Method;
+use Mollie\Api\Types\TerminalPairingCodeQuery;
 
 /**
  * @see https://docs.mollie.com/reference/terminals-request-pairing-code
@@ -31,7 +32,7 @@ class RequestTerminalPairingCodeRequest extends ResourceHydratableRequest implem
     protected function defaultQuery(): array
     {
         return [
-            'include' => $this->includeQrCode ? 'details.qrCode' : null,
+            'include' => $this->includeQrCode ? TerminalPairingCodeQuery::INCLUDE_QR_CODE : null,
         ];
     }
 

--- a/src/Http/Requests/RevokeTerminalPairingCodeRequest.php
+++ b/src/Http/Requests/RevokeTerminalPairingCodeRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mollie\Api\Http\Requests;
+
+use Mollie\Api\Resources\TerminalPairingCode;
+use Mollie\Api\Types\Method;
+
+/**
+ * @see https://docs.mollie.com/reference/terminals-revoke-pairing-code
+ */
+class RevokeTerminalPairingCodeRequest extends ResourceHydratableRequest
+{
+    protected static string $method = Method::DELETE;
+
+    protected $hydratableResource = TerminalPairingCode::class;
+
+    private string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function resolveResourcePath(): string
+    {
+        return "terminals/pairing-codes/{$this->id}";
+    }
+}

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -44,6 +44,7 @@ use Mollie\Api\EndpointCollection\SettlementRefundEndpointCollection;
 use Mollie\Api\EndpointCollection\SubscriptionEndpointCollection;
 use Mollie\Api\EndpointCollection\SubscriptionPaymentEndpointCollection;
 use Mollie\Api\EndpointCollection\TerminalEndpointCollection;
+use Mollie\Api\EndpointCollection\TerminalPairingCodeEndpointCollection;
 use Mollie\Api\EndpointCollection\WalletEndpointCollection;
 use Mollie\Api\EndpointCollection\WebhookEndpointCollection;
 use Mollie\Api\EndpointCollection\WebhookEventEndpointCollection;
@@ -107,6 +108,7 @@ use Mollie\Api\Utils\Url;
  * @property SubscriptionEndpointCollection $subscriptions
  * @property SubscriptionPaymentEndpointCollection $subscriptionPayments
  * @property TerminalEndpointCollection $terminals
+ * @property TerminalPairingCodeEndpointCollection $terminalPairingCodes
  * @property WalletEndpointCollection $wallets
  * @property WebhookEndpointCollection $webhooks
  * @property WebhookEventEndpointCollection $webhookEvents

--- a/src/Resources/ResourceRegistry.php
+++ b/src/Resources/ResourceRegistry.php
@@ -154,6 +154,7 @@ class ResourceRegistry
             Settlement::class => 'settlements',
             Subscription::class => 'subscriptions',
             Terminal::class => 'terminals',
+            TerminalPairingCode::class => 'terminal-pairing-codes',
             Webhook::class => 'webhooks',
             WebhookEvent::class => 'webhook-events',
         ];

--- a/src/Resources/TerminalPairingCode.php
+++ b/src/Resources/TerminalPairingCode.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Mollie\Api\Resources;
+
+use Mollie\Api\Types\TerminalPairingCodeStatus;
+
+/**
+ * @property \Mollie\Api\MollieApiClient $connector
+ */
+class TerminalPairingCode extends BaseResource
+{
+    /**
+     * @var string
+     */
+    public $resource;
+
+    /**
+     * The unique identifier of the pairing code.
+     *
+     * @example termpc_R7gX5Ea9bC4DkFj3G
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The mode the pairing code was created in.
+     *
+     * @var string
+     */
+    public $mode;
+
+    /**
+     * The human-readable pairing code to be entered on the terminal.
+     *
+     * @example 20eb5ca1f78b48ae9e2b
+     *
+     * @var string
+     */
+    public $code;
+
+    /**
+     * The ID of the profile the terminal is being paired with.
+     *
+     * @var string
+     */
+    public $profileId;
+
+    /**
+     * The status of the pairing code: active, expired, or revoked.
+     *
+     * @var string
+     */
+    public $status;
+
+    /**
+     * Additional pairing code data, present only when requested via the `include` parameter.
+     *
+     * @var \stdClass|null
+     */
+    public $details;
+
+    /**
+     * UTC datetime the pairing code expires, in ISO 8601 format.
+     *
+     * @example "2026-03-10T10:00:00+00:00"
+     *
+     * @var string
+     */
+    public $expiresAt;
+
+    /**
+     * UTC datetime the pairing code was revoked, in ISO 8601 format. Null if not revoked.
+     *
+     * @example "2025-12-10T10:03:23+00:00"
+     *
+     * @var string|null
+     */
+    public $revokedAt;
+
+    /**
+     * UTC datetime the pairing code was created, in ISO 8601 format.
+     *
+     * @example "2025-12-10T10:00:00+00:00"
+     *
+     * @var string
+     */
+    public $createdAt;
+
+    /**
+     * @var \stdClass
+     */
+    public $_links;
+
+    public function isActive(): bool
+    {
+        return $this->status === TerminalPairingCodeStatus::ACTIVE;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->status === TerminalPairingCodeStatus::EXPIRED;
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->status === TerminalPairingCodeStatus::REVOKED;
+    }
+}

--- a/src/Resources/TerminalPairingCodeCollection.php
+++ b/src/Resources/TerminalPairingCodeCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mollie\Api\Resources;
+
+class TerminalPairingCodeCollection extends CursorCollection
+{
+    /**
+     * The name of the collection resource in Mollie's API.
+     */
+    public static string $collectionName = 'terminal-pairing-codes';
+
+    /**
+     * Resource class name.
+     */
+    public static string $resource = TerminalPairingCode::class;
+}

--- a/src/Traits/HasEndpoints.php
+++ b/src/Traits/HasEndpoints.php
@@ -40,6 +40,7 @@ use Mollie\Api\EndpointCollection\SettlementRefundEndpointCollection;
 use Mollie\Api\EndpointCollection\SubscriptionEndpointCollection;
 use Mollie\Api\EndpointCollection\SubscriptionPaymentEndpointCollection;
 use Mollie\Api\EndpointCollection\TerminalEndpointCollection;
+use Mollie\Api\EndpointCollection\TerminalPairingCodeEndpointCollection;
 use Mollie\Api\EndpointCollection\WalletEndpointCollection;
 use Mollie\Api\EndpointCollection\WebhookEndpointCollection;
 use Mollie\Api\EndpointCollection\WebhookEventEndpointCollection;
@@ -99,6 +100,7 @@ trait HasEndpoints
             'subscriptions' => SubscriptionEndpointCollection::class,
             'subscriptionPayments' => SubscriptionPaymentEndpointCollection::class,
             'terminals' => TerminalEndpointCollection::class,
+            'terminalPairingCodes' => TerminalPairingCodeEndpointCollection::class,
             'wallets' => WalletEndpointCollection::class,
             'webhooks' => WebhookEndpointCollection::class,
             'webhookEvents' => WebhookEventEndpointCollection::class,

--- a/src/Types/TerminalPairingCodeQuery.php
+++ b/src/Types/TerminalPairingCodeQuery.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Mollie\Api\Types;
+
+class TerminalPairingCodeQuery
+{
+    /**
+     * Include the QR code object in the pairing code response.
+     */
+    const INCLUDE_QR_CODE = 'details.qrCode';
+}

--- a/src/Types/TerminalPairingCodeStatus.php
+++ b/src/Types/TerminalPairingCodeStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mollie\Api\Types;
+
+class TerminalPairingCodeStatus
+{
+    /**
+     * Valid and ready to use.
+     */
+    public const ACTIVE = 'active';
+
+    /**
+     * Past its expiry date. Cannot be used to pair new terminals.
+     */
+    public const EXPIRED = 'expired';
+
+    /**
+     * Manually revoked. Cannot be used to pair new terminals.
+     */
+    public const REVOKED = 'revoked';
+}

--- a/tests/EndpointCollection/TerminalPairingCodeEndpointCollectionTest.php
+++ b/tests/EndpointCollection/TerminalPairingCodeEndpointCollectionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\EndpointCollection;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\DynamicGetRequest;
+use Mollie\Api\Http\Requests\GetPaginatedTerminalPairingCodesRequest;
+use Mollie\Api\Http\Requests\GetTerminalPairingCodeRequest;
+use Mollie\Api\Http\Requests\RequestTerminalPairingCodeRequest;
+use Mollie\Api\Http\Requests\RevokeTerminalPairingCodeRequest;
+use Mollie\Api\Resources\TerminalPairingCode;
+use Mollie\Api\Resources\TerminalPairingCodeCollection;
+use PHPUnit\Framework\TestCase;
+
+class TerminalPairingCodeEndpointCollectionTest extends TestCase
+{
+    /** @test */
+    public function request()
+    {
+        $client = new MockMollieClient([
+            RequestTerminalPairingCodeRequest::class => MockResponse::created('terminal-pairing-code'),
+        ]);
+
+        /** @var TerminalPairingCode $pairingCode */
+        $pairingCode = $client->terminalPairingCodes->request('pfl_jA9bC4DkFj3G');
+
+        $this->assertPairingCode($pairingCode);
+    }
+
+    /** @test */
+    public function get()
+    {
+        $client = new MockMollieClient([
+            GetTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+        ]);
+
+        /** @var TerminalPairingCode $pairingCode */
+        $pairingCode = $client->terminalPairingCodes->get('termpc_R7gX5Ea9bC4DkFj3G');
+
+        $this->assertPairingCode($pairingCode);
+    }
+
+    /** @test */
+    public function page()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedTerminalPairingCodesRequest::class => MockResponse::ok('terminal-pairing-code-list'),
+            DynamicGetRequest::class => MockResponse::ok('empty-list', 'terminal-pairing-codes'),
+        ]);
+
+        /** @var TerminalPairingCodeCollection $pairingCodes */
+        $pairingCodes = $client->terminalPairingCodes->page();
+
+        $this->assertInstanceOf(TerminalPairingCodeCollection::class, $pairingCodes);
+        $this->assertGreaterThan(0, $pairingCodes->count());
+
+        foreach ($pairingCodes as $pairingCode) {
+            $this->assertPairingCode($pairingCode);
+        }
+    }
+
+    /** @test */
+    public function iterator()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedTerminalPairingCodesRequest::class => MockResponse::ok('terminal-pairing-code-list'),
+            DynamicGetRequest::class => MockResponse::ok('empty-list', 'terminal-pairing-codes'),
+        ]);
+
+        foreach ($client->terminalPairingCodes->iterator() as $pairingCode) {
+            $this->assertPairingCode($pairingCode);
+        }
+    }
+
+    /** @test */
+    public function revoke()
+    {
+        $client = new MockMollieClient([
+            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+        ]);
+
+        /** @var TerminalPairingCode $pairingCode */
+        $pairingCode = $client->terminalPairingCodes->revoke('termpc_R7gX5Ea9bC4DkFj3G');
+
+        $this->assertPairingCode($pairingCode);
+    }
+
+    protected function assertPairingCode(TerminalPairingCode $pairingCode): void
+    {
+        $this->assertInstanceOf(TerminalPairingCode::class, $pairingCode);
+        $this->assertEquals('terminal-pairing-code', $pairingCode->resource);
+        $this->assertNotEmpty($pairingCode->id);
+        $this->assertNotEmpty($pairingCode->code);
+        $this->assertNotEmpty($pairingCode->profileId);
+        $this->assertNotEmpty($pairingCode->status);
+        $this->assertNotEmpty($pairingCode->expiresAt);
+        $this->assertNotEmpty($pairingCode->createdAt);
+        $this->assertNotEmpty($pairingCode->_links);
+    }
+}

--- a/tests/EndpointCollection/TerminalPairingCodeEndpointCollectionTest.php
+++ b/tests/EndpointCollection/TerminalPairingCodeEndpointCollectionTest.php
@@ -77,13 +77,15 @@ class TerminalPairingCodeEndpointCollectionTest extends TestCase
     public function revoke()
     {
         $client = new MockMollieClient([
-            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code-revoked'),
         ]);
 
         /** @var TerminalPairingCode $pairingCode */
         $pairingCode = $client->terminalPairingCodes->revoke('termpc_R7gX5Ea9bC4DkFj3G');
 
         $this->assertPairingCode($pairingCode);
+        $this->assertTrue($pairingCode->isRevoked());
+        $this->assertNotEmpty($pairingCode->revokedAt);
     }
 
     protected function assertPairingCode(TerminalPairingCode $pairingCode): void

--- a/tests/Http/Requests/GetPaginatedTerminalPairingCodesRequestTest.php
+++ b/tests/Http/Requests/GetPaginatedTerminalPairingCodesRequestTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\GetPaginatedTerminalPairingCodesRequest;
+use Mollie\Api\Resources\TerminalPairingCodeCollection;
+use PHPUnit\Framework\TestCase;
+
+class GetPaginatedTerminalPairingCodesRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_list_terminal_pairing_codes()
+    {
+        $client = new MockMollieClient([
+            GetPaginatedTerminalPairingCodesRequest::class => MockResponse::ok('terminal-pairing-code-list'),
+        ]);
+
+        $request = new GetPaginatedTerminalPairingCodesRequest();
+
+        /** @var TerminalPairingCodeCollection */
+        $pairingCodes = $client->send($request);
+
+        $this->assertTrue($pairingCodes->getResponse()->successful());
+        $this->assertInstanceOf(TerminalPairingCodeCollection::class, $pairingCodes);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new GetPaginatedTerminalPairingCodesRequest();
+
+        $this->assertEquals('terminals/pairing-codes', $request->resolveResourcePath());
+    }
+
+    /** @test */
+    public function it_passes_profile_id_filter()
+    {
+        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, 'pfl_jA9bC4DkFj3G');
+
+        $this->assertEquals('pfl_jA9bC4DkFj3G', $request->query()->get('profileId'));
+    }
+
+    /** @test */
+    public function it_passes_pagination_params()
+    {
+        $request = new GetPaginatedTerminalPairingCodesRequest(
+            'termpc_R7gX5Ea9bC4DkFj3G',
+            10
+        );
+
+        $this->assertEquals('termpc_R7gX5Ea9bC4DkFj3G', $request->query()->get('from'));
+        $this->assertEquals(10, $request->query()->get('limit'));
+    }
+
+    /** @test */
+    public function it_passes_sort_param()
+    {
+        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, null, 'desc');
+
+        $this->assertEquals('desc', $request->query()->get('sort'));
+    }
+}

--- a/tests/Http/Requests/GetPaginatedTerminalPairingCodesRequestTest.php
+++ b/tests/Http/Requests/GetPaginatedTerminalPairingCodesRequestTest.php
@@ -37,7 +37,7 @@ class GetPaginatedTerminalPairingCodesRequestTest extends TestCase
     /** @test */
     public function it_passes_profile_id_filter()
     {
-        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, 'pfl_jA9bC4DkFj3G');
+        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, null, 'pfl_jA9bC4DkFj3G');
 
         $this->assertEquals('pfl_jA9bC4DkFj3G', $request->query()->get('profileId'));
     }
@@ -57,7 +57,7 @@ class GetPaginatedTerminalPairingCodesRequestTest extends TestCase
     /** @test */
     public function it_passes_sort_param()
     {
-        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, null, 'desc');
+        $request = new GetPaginatedTerminalPairingCodesRequest(null, null, 'desc');
 
         $this->assertEquals('desc', $request->query()->get('sort'));
     }

--- a/tests/Http/Requests/GetTerminalPairingCodeRequestTest.php
+++ b/tests/Http/Requests/GetTerminalPairingCodeRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\GetTerminalPairingCodeRequest;
+use Mollie\Api\Resources\TerminalPairingCode;
+use PHPUnit\Framework\TestCase;
+
+class GetTerminalPairingCodeRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_get_terminal_pairing_code()
+    {
+        $client = new MockMollieClient([
+            GetTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+        ]);
+
+        $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
+
+        /** @var TerminalPairingCode */
+        $pairingCode = $client->send($request);
+
+        $this->assertTrue($pairingCode->getResponse()->successful());
+        $this->assertInstanceOf(TerminalPairingCode::class, $pairingCode);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
+
+        $this->assertEquals(
+            'terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G',
+            $request->resolveResourcePath()
+        );
+    }
+
+    /** @test */
+    public function it_includes_qr_code_when_requested()
+    {
+        $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G', true);
+
+        $this->assertEquals('details.qrCode', $request->query()->get('include'));
+    }
+
+    /** @test */
+    public function it_does_not_include_qr_code_by_default()
+    {
+        $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
+
+        $this->assertNull($request->query()->get('include'));
+    }
+}

--- a/tests/Http/Requests/GetTerminalPairingCodeRequestTest.php
+++ b/tests/Http/Requests/GetTerminalPairingCodeRequestTest.php
@@ -46,6 +46,22 @@ class GetTerminalPairingCodeRequestTest extends TestCase
     }
 
     /** @test */
+    public function it_hydrates_qr_code_details_when_requested()
+    {
+        $client = new MockMollieClient([
+            GetTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code-with-qr'),
+        ]);
+
+        $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G', true);
+
+        /** @var TerminalPairingCode */
+        $pairingCode = $client->send($request);
+
+        $this->assertInstanceOf(\stdClass::class, $pairingCode->details);
+        $this->assertNotEmpty($pairingCode->details->qrCode->src);
+    }
+
+    /** @test */
     public function it_does_not_include_qr_code_by_default()
     {
         $request = new GetTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');

--- a/tests/Http/Requests/RequestTerminalPairingCodeRequestTest.php
+++ b/tests/Http/Requests/RequestTerminalPairingCodeRequestTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\RequestTerminalPairingCodeRequest;
+use Mollie\Api\Resources\TerminalPairingCode;
+use PHPUnit\Framework\TestCase;
+
+class RequestTerminalPairingCodeRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_request_terminal_pairing_code()
+    {
+        $client = new MockMollieClient([
+            RequestTerminalPairingCodeRequest::class => MockResponse::created('terminal-pairing-code'),
+        ]);
+
+        $request = new RequestTerminalPairingCodeRequest('pfl_jA9bC4DkFj3G');
+
+        /** @var TerminalPairingCode */
+        $pairingCode = $client->send($request);
+
+        $this->assertTrue($pairingCode->getResponse()->successful());
+        $this->assertInstanceOf(TerminalPairingCode::class, $pairingCode);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new RequestTerminalPairingCodeRequest('pfl_jA9bC4DkFj3G');
+
+        $this->assertEquals('terminals/pairing-codes', $request->resolveResourcePath());
+    }
+
+    /** @test */
+    public function it_includes_profile_id_in_payload()
+    {
+        $request = new RequestTerminalPairingCodeRequest('pfl_jA9bC4DkFj3G');
+
+        $this->assertEquals('pfl_jA9bC4DkFj3G', $request->payload()->get('profileId'));
+    }
+
+    /** @test */
+    public function it_includes_qr_code_when_requested()
+    {
+        $request = new RequestTerminalPairingCodeRequest('pfl_jA9bC4DkFj3G', true);
+
+        $this->assertEquals('details.qrCode', $request->query()->get('include'));
+    }
+
+    /** @test */
+    public function it_does_not_include_qr_code_by_default()
+    {
+        $request = new RequestTerminalPairingCodeRequest('pfl_jA9bC4DkFj3G');
+
+        $this->assertNull($request->query()->get('include'));
+    }
+}

--- a/tests/Http/Requests/RevokeTerminalPairingCodeRequestTest.php
+++ b/tests/Http/Requests/RevokeTerminalPairingCodeRequestTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Http\Requests;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\RevokeTerminalPairingCodeRequest;
+use Mollie\Api\Resources\TerminalPairingCode;
+use PHPUnit\Framework\TestCase;
+
+class RevokeTerminalPairingCodeRequestTest extends TestCase
+{
+    /** @test */
+    public function it_can_revoke_terminal_pairing_code()
+    {
+        $client = new MockMollieClient([
+            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+        ]);
+
+        $request = new RevokeTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
+
+        /** @var TerminalPairingCode */
+        $pairingCode = $client->send($request);
+
+        $this->assertTrue($pairingCode->getResponse()->successful());
+        $this->assertInstanceOf(TerminalPairingCode::class, $pairingCode);
+    }
+
+    /** @test */
+    public function it_resolves_correct_resource_path()
+    {
+        $request = new RevokeTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
+
+        $this->assertEquals(
+            'terminals/pairing-codes/termpc_R7gX5Ea9bC4DkFj3G',
+            $request->resolveResourcePath()
+        );
+    }
+}

--- a/tests/Http/Requests/RevokeTerminalPairingCodeRequestTest.php
+++ b/tests/Http/Requests/RevokeTerminalPairingCodeRequestTest.php
@@ -14,7 +14,7 @@ class RevokeTerminalPairingCodeRequestTest extends TestCase
     public function it_can_revoke_terminal_pairing_code()
     {
         $client = new MockMollieClient([
-            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code'),
+            RevokeTerminalPairingCodeRequest::class => MockResponse::ok('terminal-pairing-code-revoked'),
         ]);
 
         $request = new RevokeTerminalPairingCodeRequest('termpc_R7gX5Ea9bC4DkFj3G');
@@ -24,6 +24,8 @@ class RevokeTerminalPairingCodeRequestTest extends TestCase
 
         $this->assertTrue($pairingCode->getResponse()->successful());
         $this->assertInstanceOf(TerminalPairingCode::class, $pairingCode);
+        $this->assertTrue($pairingCode->isRevoked());
+        $this->assertNotEmpty($pairingCode->revokedAt);
     }
 
     /** @test */

--- a/tests/MollieApiClientTest.php
+++ b/tests/MollieApiClientTest.php
@@ -93,6 +93,7 @@ class MollieApiClientTest extends TestCase
         $this->assertNotEmpty($client_copy->customerPayments);
         $this->assertNotEmpty($client_copy->payments);
         $this->assertNotEmpty($client_copy->methods);
+        $this->assertNotEmpty($client_copy->terminalPairingCodes);
     }
 
     /** @test */


### PR DESCRIPTION
## Summary
- add terminal pairing codes create, get, revoke, and paginated list endpoints
- add terminal pairing code resource, collection and fake responses
- wire terminal pairing codes into the client endpoint and resource registries

## Tests
- composer test -- --colors=never