### PR TITLE
fix: support applicationFee on payment link creation

### DIFF
--- a/src/Factories/CreatePaymentLinkRequestFactory.php
+++ b/src/Factories/CreatePaymentLinkRequestFactory.php
@@ -26,6 +26,7 @@ class CreatePaymentLinkRequestFactory extends RequestFactory
             $this->transformFromPayload('billingAddress', fn ($item) => Address::fromArray($item)),
             $this->transformFromPayload('shippingAddress', fn ($item) => Address::fromArray($item)),
             $this->transformFromPayload('minimumAmount', fn ($amount) => MoneyFactory::new($amount)->create()),
+            $this->transformFromPayload('applicationFee', fn ($item) => ApplicationFeeFactory::new($item)->create()),
         );
     }
 

--- a/src/Http/Requests/CreatePaymentLinkRequest.php
+++ b/src/Http/Requests/CreatePaymentLinkRequest.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Mollie\Api\Contracts\HasPayload;
 use Mollie\Api\Contracts\SupportsTestmodeInPayload;
 use Mollie\Api\Http\Data\Address;
+use Mollie\Api\Http\Data\ApplicationFee;
 use Mollie\Api\Http\Data\DataCollection;
 use Mollie\Api\Http\Data\DateTime;
 use Mollie\Api\Http\Data\Money;
@@ -61,6 +62,8 @@ class CreatePaymentLinkRequest extends ResourceHydratableRequest implements HasP
 
     private ?Money $minimumAmount;
 
+    private ?ApplicationFee $applicationFee;
+
     public function __construct(
         string $description,
         ?Money $amount = null,
@@ -75,7 +78,8 @@ class CreatePaymentLinkRequest extends ResourceHydratableRequest implements HasP
         ?DataCollection $lines = null,
         ?Address $billingAddress = null,
         ?Address $shippingAddress = null,
-        ?Money $minimumAmount = null
+        ?Money $minimumAmount = null,
+        ?ApplicationFee $applicationFee = null
     ) {
         $this->description = $description;
         $this->amount = $amount;
@@ -91,6 +95,7 @@ class CreatePaymentLinkRequest extends ResourceHydratableRequest implements HasP
         $this->billingAddress = $billingAddress;
         $this->shippingAddress = $shippingAddress;
         $this->minimumAmount = $minimumAmount;
+        $this->applicationFee = $applicationFee;
     }
 
     protected function defaultPayload(): array
@@ -110,6 +115,7 @@ class CreatePaymentLinkRequest extends ResourceHydratableRequest implements HasP
             'lines' => $this->lines,
             'billingAddress' => $this->billingAddress,
             'shippingAddress' => $this->shippingAddress,
+            'applicationFee' => $this->applicationFee,
         ];
     }
 

--- a/src/MollieApiClient.php
+++ b/src/MollieApiClient.php
@@ -132,7 +132,7 @@ class MollieApiClient implements Connector
     /**
      * Version of our client.
      */
-    public const CLIENT_VERSION = '3.12.0';
+    public const CLIENT_VERSION = '3.13.0';
 
     /**
      * Endpoint of the remote API.

--- a/tests/Factories/CreatePaymentLinkRequestFactoryTest.php
+++ b/tests/Factories/CreatePaymentLinkRequestFactoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Factories;
 
 use Mollie\Api\Factories\CreatePaymentLinkRequestFactory;
 use Mollie\Api\Http\Data\Address;
+use Mollie\Api\Http\Data\ApplicationFee;
 use Mollie\Api\Http\Data\DataCollection;
 use Mollie\Api\Http\Data\DateTime;
 use Mollie\Api\Http\Data\Money;
@@ -215,6 +216,55 @@ class CreatePaymentLinkRequestFactoryTest extends TestCase
 
         $this->assertInstanceOf(Address::class, $payload['shippingAddress']);
         $this->assertEquals('Amsterdam', $payload['shippingAddress']->city);
+    }
+
+    /** @test */
+    public function it_maps_application_fee()
+    {
+        $request = CreatePaymentLinkRequestFactory::new()
+            ->withPayload([
+                'description' => 'Order #12345',
+                'amount' => [
+                    'currency' => 'EUR',
+                    'value' => '100.00',
+                ],
+                'redirectUrl' => 'https://example.com/redirect',
+                'applicationFee' => [
+                    'amount' => [
+                        'currency' => 'EUR',
+                        'value' => '10.00',
+                    ],
+                    'description' => 'Platform fee',
+                ],
+            ])
+            ->create();
+
+        $payload = $request->payload()->all();
+
+        $this->assertInstanceOf(ApplicationFee::class, $payload['applicationFee']);
+        $this->assertInstanceOf(Money::class, $payload['applicationFee']->amount);
+        $this->assertEquals('EUR', $payload['applicationFee']->amount->currency);
+        $this->assertEquals('10.00', $payload['applicationFee']->amount->value);
+        $this->assertEquals('Platform fee', $payload['applicationFee']->description);
+    }
+
+    /** @test */
+    public function it_returns_null_when_application_fee_is_not_provided()
+    {
+        $request = CreatePaymentLinkRequestFactory::new()
+            ->withPayload([
+                'description' => 'Order #12345',
+                'amount' => [
+                    'currency' => 'EUR',
+                    'value' => '100.00',
+                ],
+                'redirectUrl' => 'https://example.com/redirect',
+            ])
+            ->create();
+
+        $payload = $request->payload()->all();
+
+        $this->assertNull($payload['applicationFee']);
     }
 
     /** @test */


### PR DESCRIPTION
Payment links now support application fees. Previously the fee was silently dropped when creating a link, so Mollie Connect platforms couldn't charge a fee on payment links at all. Brings payment links in line with payments, subscriptions, and customer payments, which already supported this. Covered by tests.