### PR TITLE
fix: correct @var type for Payment::status from string to PaymentStatus

### DIFF
--- a/src/Resources/Payment.php
+++ b/src/Resources/Payment.php
@@ -96,7 +96,7 @@ class Payment extends BaseResource implements EmbeddedResourcesContract
     /**
      * The status of the payment.
      *
-     * @var string
+     * @var \Mollie\Api\Types\PaymentStatus
      */
     public $status = PaymentStatus::OPEN;
 


### PR DESCRIPTION
Fixes #896 - changed @var string to @var \Mollie\Api\Types\PaymentStatus for the $status property (1 line fix).