### PR TITLE
[agent] fix devex runtime hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ php-scoper.phar
 php-scoper.phar.pubkey
 .php-cs-fixer.cache
 .phpunit.result.cache
+.agents/
+.ai/
+.codex/
+.claude/
+.scribe.yaml
+.anvil.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PHP SDK for the Mollie API (https://docs.mollie.com/reference/overview). Supports PHP 7.4–8.4. Namespace: `Mollie\Api`.
+PHP SDK for the Mollie API (https://docs.mollie.com/reference/overview). Supports PHP ^8.2. Namespace: `Mollie\Api`.
 
 ## Commands
 
 ```bash
 # Run all tests (parallel)
-composer test                    # or: vendor/bin/paratest --verbose
+composer test                    # runs: vendor/bin/pest --parallel
 
 # Run a single test file
-vendor/bin/phpunit tests/Path/To/TestFile.php
+vendor/bin/pest tests/Path/To/TestFile.php
 
 # Run a single test method
-vendor/bin/phpunit --filter testMethodName tests/Path/To/TestFile.php
+vendor/bin/pest --filter testMethodName tests/Path/To/TestFile.php
 
 # Static analysis (level 5)
 vendor/bin/phpstan
@@ -99,6 +99,6 @@ Test fixtures live in `tests/Fixtures/`. Documentation and code examples are in 
 
 ## CI
 
-- **Tests**: PHPUnit via Paratest across PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4
+- **Tests**: Pest v3 across PHP 8.2, 8.3, 8.4
 - **Static analysis**: PHPStan level 5 (with baseline)
 - **Code style**: PHP CS Fixer

--- a/docs/superpowers/specs/2026-05-22-money-builder-design.md
+++ b/docs/superpowers/specs/2026-05-22-money-builder-design.md
@@ -1,0 +1,187 @@
+# Money builder — design spec
+
+**Date:** 2026-05-22
+**Status:** Approved
+**Target version:** 4.0.0
+**Closes:** part of issue #876 (Money convenience factories)
+
+## Overview
+
+Add a fluent builder entry point to `Mollie\Api\Http\Data\Money` so consumers can construct Money instances via `Money::of('EUR')->minorUnits(1000)` instead of (or alongside) the existing static factories. The builder is consistency-driven — it matches the v4 builder idiom shipped with `PaymentIncludes`, `PaymentEmbeds`, etc. — and it is strictly additive. Existing construction paths (`new Money(...)`, `Money::fromMinorUnits(...)`, `Money::fromArray(...)`) remain valid in v4.
+
+## Goals
+
+- Provide a fluent construction surface that reads naturally in a Laravel/Symfony codebase: `Money::of('EUR')->minorUnits(1000)`.
+- Keep the construction surface narrow — exactly 2 amount-shape methods (`minorUnits` for int, `fromString` for raw decimal string). Anything else is consumer-defined via the `Macroable` trait on `Money`.
+- Preserve full BC: existing `Money` constructors and factories work unchanged.
+- Match the v4 builder idiom (consistency with `PaymentIncludes::mandates()->customer()` style).
+
+## Non-goals
+
+- Not a replacement for `Money::fromMinorUnits()` — that static factory stays.
+- Not a builder for arbitrary unit conversion (major units, cents alias, brick/money interop, moneyphp/money interop). Those are consumer extensions via macros.
+- Not mutable. Both `Money` and the builder are `readonly class`.
+- No new third-party dependencies. `Macroable` is the SDK's own trait.
+
+## Public API
+
+```php
+// Two terminal methods. Both return Money directly. No ->build() or ->make() needed.
+Money::of('EUR')->minorUnits(1000);        // → Money { currency: "EUR", value: "10.00" }
+Money::of('EUR')->fromString('10.00');     // → Money { currency: "EUR", value: "10.00" }
+
+// Coexists with the existing static factory.
+Money::fromMinorUnits('EUR', 1000);        // ← still works
+new Money('EUR', '10.00');                 // ← still works (readonly ctor)
+
+// Currency is uppercased by Money::of() to match Mollie's API convention.
+Money::of('jpy')->minorUnits(1000);        // → Money { currency: "JPY", value: "1000" }
+
+// Negative amounts (refunds) supported on minorUnits, mirrored from fromMinorUnits.
+Money::of('EUR')->minorUnits(-1000);       // → Money { currency: "EUR", value: "-10.00" }
+```
+
+The builder is intentionally one-shot: `of()` accepts a currency, and either `minorUnits()` or `fromString()` terminates the chain. There is no `->in()` or `->currency()` re-setter — if a consumer needs a different currency, they call `Money::of()` again.
+
+## Implementation
+
+### `src/Http/Data/Money.php` — add `of()` static method
+
+```php
+readonly class Money implements Arrayable
+{
+    use ComposableFromArray;
+    use HasCurrencyConvenienceMethods;
+    use Macroable;
+
+    public function __construct(
+        public string $currency,
+        public string $value,
+    ) {}
+
+    public static function of(string $currency): MoneyBuilder
+    {
+        return new MoneyBuilder(strtoupper($currency));
+    }
+
+    public static function fromMinorUnits(string $currency, int $amount): self
+    {
+        // existing implementation unchanged
+    }
+
+    public function toArray(): array
+    {
+        // unchanged
+    }
+}
+```
+
+### `src/Http/Data/MoneyBuilder.php` — new file
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\Api\Http\Data;
+
+readonly class MoneyBuilder
+{
+    public function __construct(
+        private string $currency,
+    ) {}
+
+    public function minorUnits(int $amount): Money
+    {
+        return Money::fromMinorUnits($this->currency, $amount);
+    }
+
+    public function fromString(string $value): Money
+    {
+        return new Money($this->currency, $value);
+    }
+}
+```
+
+Two terminal methods. `minorUnits` delegates to the existing `Money::fromMinorUnits` so the currency-exponent math lives in one place. `fromString` delegates to the constructor directly.
+
+### Why `MoneyBuilder` is its own class
+
+- A separate class is `readonly` and small enough to be inlined mentally by readers.
+- Static analysis (PHPStan) gets a precise return type at each step: `Money::of()` → `MoneyBuilder`, `->minorUnits()` → `Money`. No magic-method gymnastics.
+- IDE autocomplete works for free — no `@method static` annotations needed.
+- An anonymous-class or trait-based alternative would hide the type at static analysis time and tax discoverability.
+
+## Strict typing
+
+- `Money::of(string $currency): MoneyBuilder` — currency is required, must be a string.
+- `MoneyBuilder::minorUnits(int $amount): Money` — `int` only. Passing a string fails fast.
+- `MoneyBuilder::fromString(string $value): Money` — `string` only. Passing an int fails fast.
+
+No `int|string` union types. The split is the whole point: each method's parameter type names the shape of the input.
+
+## `Macroable` extension
+
+`Macroable` stays on `Money`, not on `MoneyBuilder`. Consumer-defined macros operate on the final value object:
+
+```php
+Money::macro('fromBrick', fn ($brick) =>
+    Money::of($brick->getCurrency()->getCurrencyCode())
+        ->fromString((string) $brick->getAmount())
+);
+
+Money::fromBrick($brickMoney);    // consumer-defined factory
+```
+
+Macros on the builder itself were considered and rejected — building on the builder would require maintaining two macro registries, and consumers would inevitably split their helpers across both. One registry on the value object covers every extension case.
+
+## Tests
+
+New file: `tests/Http/Data/MoneyBuilderTest.php`. Existing `Money` tests stay unchanged.
+
+Test cases (Pest v3 syntax, parallel-safe):
+
+```
+of('EUR')->minorUnits(1000)         → Money { currency: "EUR", value: "10.00" }
+of('jpy')->minorUnits(1000)         → Money { currency: "JPY", value: "1000" }     // uppercase + no-decimal currency
+of('BHD')->minorUnits(1000)         → Money { currency: "BHD", value: "1.000" }     // 3-decimal currency
+of('EUR')->minorUnits(-1000)        → Money { currency: "EUR", value: "-10.00" }    // negative (refund)
+of('EUR')->minorUnits(0)            → Money { currency: "EUR", value: "0.00" }      // zero
+of('EUR')->fromString('10.00')      → Money { currency: "EUR", value: "10.00" }     // string passthrough
+of('eur')->fromString('10.00')      → Money { currency: "EUR", value: "10.00" }     // uppercase via of()
+```
+
+Plus one test asserting the builder is itself a `readonly` class (introspection).
+
+## Docs
+
+- `README.md` — replace the canonical Money construction snippet with `Money::of('EUR')->minorUnits(1000)`. Keep `Money::fromMinorUnits()` referenced as still-valid.
+- `CHANGELOG.md` `[4.0.0]` `### Added` — one bullet.
+- `UPGRADING.md` — short subsection under "Convenience constructors" noting both forms are valid.
+
+## File touch list
+
+| File | Change |
+|---|---|
+| `src/Http/Data/Money.php` | Add `of()` static method |
+| `src/Http/Data/MoneyBuilder.php` | New file (~25 LOC) |
+| `tests/Http/Data/MoneyBuilderTest.php` | New file (~80 LOC, 7 tests) |
+| `README.md` | Update construction snippet |
+| `CHANGELOG.md` | `[4.0.0]` `### Added` bullet |
+| `UPGRADING.md` | Subsection on Money construction options |
+
+Estimated total: ~140 LOC across 6 files. 2-3 hours including tests and docs.
+
+## North star alignment
+
+- **Principle 1 (Mirror Mollie API):** `value` and `currency` field names match Mollie's wire format. `minorUnits` semantics match Mollie's currency-exponent expectations.
+- **Principle 2 (Type safety + IDE discoverability):** Builder produces precise step-wise types. Method names describe input shape. No union types or magic.
+- **Principle 4 (BC sacred):** Strictly additive. Every existing construction path keeps working.
+- **Principle 7 (Defer features over breaking adopters):** Macroable extension point covers the brick/money + moneyphp/money interop ask in #876 without forcing those deps on every consumer.
+
+## Out of scope (deferred or rejected)
+
+- `majorUnits(int $amount)` method — not requested in this round; can be added in 4.1 if real demand surfaces.
+- Brick/money + moneyphp/money interop methods (#876 wish list) — consumer-defined via Macroable. Documented in UPGRADING.md as the recommended pattern.
+- Float input support — explicitly rejected by `fromMinorUnits` for the same precision-loss reason. Builder follows that precedent.
+- Builder for other value objects (`Address::of()`, `Url::of()`) — not part of this design. Money is the high-traffic case where the builder pays off; the others can adopt the pattern later if useful.

--- a/solo.yml
+++ b/solo.yml
@@ -1,0 +1,7 @@
+name: mollie-api-php
+processes:
+  gdiff:
+    command: |
+      git fetch origin --quiet
+      gdiff origin/main
+    auto_start: false

--- a/src/CompatibilityChecker.php
+++ b/src/CompatibilityChecker.php
@@ -11,7 +11,7 @@ class CompatibilityChecker
     /**
      * @var string
      */
-    public const MIN_PHP_VERSION = '7.4';
+    public const MIN_PHP_VERSION = '8.2';
 
     public static function make(): self
     {

--- a/src/Http/Requests/CreateSessionRequest.php
+++ b/src/Http/Requests/CreateSessionRequest.php
@@ -41,7 +41,8 @@ class CreateSessionRequest extends ResourceHydratableRequest implements HasPaylo
         private ?array $metadata = null,
         private ?string $paymentWebhook = null,
         private ?string $profileId = null,
-    ) {}
+    ) {
+    }
 
     protected function defaultPayload(): array
     {

--- a/src/Utils/Debugger.php
+++ b/src/Utils/Debugger.php
@@ -9,7 +9,7 @@ use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Symfony\Component\VarDumper\VarDumper;
+use RuntimeException;
 
 class Debugger
 {
@@ -21,17 +21,24 @@ class Debugger
     public static $dieHandler = null;
 
     /**
+     * @var bool|null
+     */
+    private static ?bool $symfonyVarDumperExists = null;
+
+    /**
      * Debug a request with Symfony Var Dumper
      */
     public static function symfonyRequestDebugger(PendingRequest $pendingRequest, RequestInterface $psrRequest): void
     {
+        self::ensureSymfonyVarDumperIsAvailable();
+
         $headers = [];
 
         foreach ($psrRequest->getHeaders() as $headerName => $value) {
             $headers[$headerName] = implode(';', $value);
         }
 
-        VarDumper::dump([
+        \Symfony\Component\VarDumper\VarDumper::dump([
             'request' => get_class($pendingRequest->getRequest()),
             'method' => $psrRequest->getMethod(),
             'uri' => (string) $psrRequest->getUri(),
@@ -45,17 +52,30 @@ class Debugger
      */
     public static function symfonyResponseDebugger(Response $response, ResponseInterface $psrResponse): void
     {
+        self::ensureSymfonyVarDumperIsAvailable();
+
         $headers = [];
 
         foreach ($psrResponse->getHeaders() as $headerName => $value) {
             $headers[$headerName] = implode(';', $value);
         }
 
-        VarDumper::dump([
+        \Symfony\Component\VarDumper\VarDumper::dump([
             'status' => $response->status(),
             'headers' => $headers,
             'body' => json_decode((string) $psrResponse->getBody(), true),
         ]);
+    }
+
+    private static function ensureSymfonyVarDumperIsAvailable(): void
+    {
+        if (self::$symfonyVarDumperExists ?? class_exists(\Symfony\Component\VarDumper\VarDumper::class)) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'Debugging with the default Symfony debugger requires symfony/var-dumper. Install symfony/var-dumper with Composer or pass a custom debug callback.'
+        );
     }
 
     /**

--- a/tests/CompatibilityCheckerTest.php
+++ b/tests/CompatibilityCheckerTest.php
@@ -25,6 +25,11 @@ class CompatibilityCheckerTest extends \PHPUnit\Framework\TestCase
             ->getMock();
     }
 
+    public function test_minimum_php_version_matches_v4_composer_requirement()
+    {
+        $this->assertSame('8.2', CompatibilityChecker::MIN_PHP_VERSION);
+    }
+
     public function test_check_compatibility_throws_exception_on_php_version()
     {
         $this->expectException(\Mollie\Api\Exceptions\IncompatiblePlatformException::class);

--- a/tests/Resources/ResourceHydratorTest.php
+++ b/tests/Resources/ResourceHydratorTest.php
@@ -6,9 +6,9 @@ namespace Tests\Resources;
 
 use DateTimeImmutable;
 use Mollie\Api\Contracts\EmbeddedResourcesContract;
+use Mollie\Api\Exceptions\EmbeddedResourcesNotParseableException;
 use Mollie\Api\Fake\MockMollieClient;
 use Mollie\Api\Http\Data\Money;
-use Mollie\Api\Exceptions\EmbeddedResourcesNotParseableException;
 use Mollie\Api\Http\Response;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\AnyResource;

--- a/tests/Utils/DebuggerTest.php
+++ b/tests/Utils/DebuggerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Utils;
+
+use Mollie\Api\Fake\MockMollieClient;
+use Mollie\Api\Http\PendingRequest;
+use Mollie\Api\Http\Response;
+use Mollie\Api\Utils\Debugger;
+use Nyholm\Psr7\Request as PsrRequest;
+use Nyholm\Psr7\Response as PsrResponse;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use RuntimeException;
+use Tests\Fixtures\Requests\DynamicGetRequest;
+
+class DebuggerTest extends TestCase
+{
+    public function test_default_request_debugger_reports_missing_symfony_var_dumper()
+    {
+        $this->withMissingSymfonyVarDumper(function (): void {
+            $pendingRequest = new PendingRequest(new MockMollieClient, new DynamicGetRequest(''));
+            $psrRequest = new PsrRequest('GET', 'https://api.mollie.com/v2/test');
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('requires symfony/var-dumper');
+
+            Debugger::symfonyRequestDebugger($pendingRequest, $psrRequest);
+        });
+    }
+
+    public function test_default_debugger_reports_missing_symfony_var_dumper()
+    {
+        $this->withMissingSymfonyVarDumper(function (): void {
+            $psrRequest = new PsrRequest('GET', 'https://api.mollie.com/v2/test');
+            $psrResponse = new PsrResponse(200, ['X-Test' => 'yes'], '{"resource":"test"}');
+            $pendingRequest = new PendingRequest(new MockMollieClient, new DynamicGetRequest(''));
+            $response = new Response($psrResponse, $psrRequest, $pendingRequest);
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('requires symfony/var-dumper');
+
+            Debugger::symfonyResponseDebugger($response, $psrResponse);
+        });
+    }
+
+    private function withMissingSymfonyVarDumper(callable $callback): void
+    {
+        $availability = new ReflectionProperty(Debugger::class, 'symfonyVarDumperExists');
+        $availability->setAccessible(true);
+        $availability->setValue(null, false);
+
+        try {
+            $callback();
+        } finally {
+            $availability->setValue(null, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Guard default Debugger helpers when symfony/var-dumper is unavailable, returning an actionable RuntimeException instead of a class-not-found fatal.
- Update CompatibilityChecker's v4 PHP floor to 8.2 and cover it with a focused test.
- Refresh stale CLAUDE.md facts for PHP support, Pest v3 commands, and CI matrix.
- Ignore local agent/tooling artifacts while leaving docs/NORTH_STAR.md untouched.

## Test plan
- `./vendor/bin/pest tests/CompatibilityCheckerTest.php tests/Utils/DebuggerTest.php --compact`
- `./vendor/bin/pest tests/MollieApiClientTest.php --filter debugging --compact`
- `php -l src/Utils/Debugger.php && php -l src/CompatibilityChecker.php && php -l tests/CompatibilityCheckerTest.php && php -l tests/Utils/DebuggerTest.php`
- Manual grep of CLAUDE.md for stale PHP 7.4/PHPUnit/Paratest facts

## Notes
- Focused tests emit existing PHPUnit 12 deprecation warnings from the current phpunit.xml schema/doc-comment metadata; they still pass.
- The debug guard is tested through a private static reflection seam so vendor dependencies did not need to be removed.
